### PR TITLE
Fix compiler warnings in `ethereum/contracts/coreRelayer/CoreRelayerGovernance.sol`

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayerGovernance.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerGovernance.sol
@@ -38,7 +38,8 @@ abstract contract CoreRelayerGovernance is
     function upgrade(uint16 thisRelayerChainId, address newImplementation) public onlyOwner {
         require(thisRelayerChainId == chainId(), "3");
 
-        address currentImplementation = _getImplementation();
+        // cache currentImplementation for event
+        //address currentImplementation = _getImplementation();
 
         _upgradeTo(newImplementation);
 
@@ -72,8 +73,8 @@ abstract contract CoreRelayerGovernance is
 
         require(msg.sender == newOwner, "6");
 
-        // cache currentOwner for Event
-        address currentOwner = owner();
+        // cache currentOwner for event
+        //address currentOwner = owner();
 
         // update the owner in the contract state and reset the pending owner
         setOwner(newOwner);


### PR DESCRIPTION
Fix compiler warnings about local variables not being used in `ethereum/contracts/coreRelayer/CoreRelayerGovernance.sol`:

```
warning[2072]: Warning: Unused local variable.
  --> contracts/coreRelayer/CoreRelayerGovernance.sol:41:9:
   |
41 |         address currentImplementation = _getImplementation();
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^



warning[2072]: Warning: Unused local variable.
  --> contracts/coreRelayer/CoreRelayerGovernance.sol:76:9:
   |
76 |         address currentOwner = owner();
   |         ^^^^^^^^^^^^^^^^^^^^
```


I worked under the assumption that the events `OwnershipTransfered` and `ContractUpgraded` are still not being used. Left the code commented out just in case, could delete it if that's appropriate.