### PR TITLE
Removes redundant abicoder pragmas.

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.0;
 
-pragma experimental ABIEncoderV2;
-
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 import "./CoreRelayer.sol";

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.0;
 
-pragma experimental ABIEncoderV2;
-
 import "./CoreRelayerGovernance.sol";
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.0;
 
-pragma experimental ABIEncoderV2;
-
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 import "./RelayProvider.sol";

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -3,8 +3,6 @@
 
 pragma solidity ^0.8.0;
 
-pragma experimental ABIEncoderV2;
-
 import "./RelayProviderGovernance.sol";
 
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";


### PR DESCRIPTION
The ABI encoder used by the compiler defaults to v2 of the specification in the v0.8 series.
See https://docs.soliditylang.org/en/latest/080-breaking-changes.html#silent-changes-of-the-semantics

Alternatively, we could change them to `pragma abicoder v2;`. This would be mostly useful if we expect new ABI encodings to be released. Which, as far as I know, is not going to happen in the near future.