### PR TITLE
Replace strings with typed errors

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -515,7 +515,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         if (!valid) {
             revert InvalidRedeliveryVM(reason);
         }
-        if(!verifyRelayerVM(redeliveryVM)) {
+        if (!verifyRelayerVM(redeliveryVM)) {
             // Redelivery VM has an invalid emitter
             revert InvalidEmitterInRedeliveryVM();
         }
@@ -526,7 +526,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         );
 
         //redelivery request cannot have already been attempted
-        if (isDeliveryCompleted(redeliveryVM.hash)){
+        if (isDeliveryCompleted(redeliveryVM.hash)) {
             revert AlreadyDelivered();
         }
 
@@ -544,20 +544,17 @@ contract CoreRelayer is CoreRelayerGovernance {
 
         // The same relay provider must be specified when doing a single VAA redeliver.
         address providerAddress = fromWormholeFormat(redeliveryInstruction.executionParameters.providerDeliveryAddress);
-        if (
-            providerAddress != fromWormholeFormat(originalInstruction.executionParameters.providerDeliveryAddress)
-        ) {
+        if (providerAddress != fromWormholeFormat(originalInstruction.executionParameters.providerDeliveryAddress)) {
             revert MismatchingRelayProvidersInRedelivery();
         }
 
-
         // msg.sender must be the provider
-        if(msg.sender != providerAddress) {
+        if (msg.sender != providerAddress) {
             revert ProviderAddressIsNotSender();
         }
 
         //redelivery must target this chain
-        if(chainId() != redeliveryInstruction.targetChain) {
+        if (chainId() != redeliveryInstruction.targetChain) {
             revert RedeliveryRequestDoesNotTargetThisChain();
         }
 
@@ -567,8 +564,10 @@ contract CoreRelayer is CoreRelayerGovernance {
         }
 
         //relayer must have covered the necessary funds
-        if ( msg.value <
-                redeliveryInstruction.newMaximumRefundTarget + redeliveryInstruction.newApplicationBudgetTarget + wormhole().messageFee()
+        if (
+            msg.value
+                < redeliveryInstruction.newMaximumRefundTarget + redeliveryInstruction.newApplicationBudgetTarget
+                    + wormhole().messageFee()
         ) {
             revert InsufficientRelayerFunds();
         }
@@ -594,13 +593,13 @@ contract CoreRelayer is CoreRelayerGovernance {
         if (!valid) {
             revert InvalidVaa(targetParams.deliveryIndex);
         }
-        if(!verifyRelayerVM(deliveryVM)) {
+        if (!verifyRelayerVM(deliveryVM)) {
             revert InvalidEmitter();
         }
 
         DeliveryInstructionsContainer memory container = decodeDeliveryInstructionsContainer(deliveryVM.payload);
         //ensure this is a funded delivery, not a failed forward.
-        if(!container.sufficientlyFunded) {
+        if (!container.sufficientlyFunded) {
             revert DeliveryRequestNotSufficientlyFunded();
         }
 
@@ -608,13 +607,15 @@ contract CoreRelayer is CoreRelayerGovernance {
         DeliveryInstruction memory deliveryInstruction = container.instructions[targetParams.multisendIndex];
 
         //make sure the specified relayer is the relayer delivering this message
-        if(fromWormholeFormat(deliveryInstruction.executionParameters.providerDeliveryAddress) != msg.sender) {
+        if (fromWormholeFormat(deliveryInstruction.executionParameters.providerDeliveryAddress) != msg.sender) {
             revert UnexpectedRelayer();
         }
 
         //make sure relayer passed in sufficient funds
-        if (msg.value <
-            deliveryInstruction.maximumRefundTarget + deliveryInstruction.applicationBudgetTarget + wormhole.messageFee()
+        if (
+            msg.value
+                < deliveryInstruction.maximumRefundTarget + deliveryInstruction.applicationBudgetTarget
+                    + wormhole.messageFee()
         ) {
             revert InsufficientRelayerFunds();
         }

--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./CoreRelayer.sol";
 
 contract CoreRelayerImplementation is CoreRelayer {
-
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -8,6 +8,9 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./CoreRelayer.sol";
 
 contract CoreRelayerImplementation is CoreRelayer {
+
+    error ImplementationAlreadyInitialized();
+
     function initialize() public virtual initializer {
         // this function needs to be exposed for an upgrade to pass
     }
@@ -15,7 +18,9 @@ contract CoreRelayerImplementation is CoreRelayer {
     modifier initializer() {
         address impl = ERC1967Upgrade._getImplementation();
 
-        require(!isInitialized(impl), "already initialized");
+        if (isInitialized(impl)) {
+            revert ImplementationAlreadyInitialized();
+        }
 
         setInitialized(impl);
 

--- a/ethereum/contracts/coreRelayer/CoreRelayerLibrary.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerLibrary.sol
@@ -6,6 +6,14 @@ import "../libraries/external/BytesLib.sol";
 library CoreRelayerLibrary {
     using BytesLib for bytes;
 
+    error WrongModule(bytes32 module);
+    error InvalidContractUpgradeAction(uint8 action);
+    error InvalidContractUpgradeLength(uint256 length);
+    error InvalidRegisterChainAction(uint8);
+    error InvalidRegisterChainLength(uint256);
+    error InvalidDefaultProviderAction(uint8);
+    error InvalidDefaultProviderLength(uint256);
+
     function parseUpgrade(bytes memory encodedUpgrade, bytes32 module)
         public
         pure
@@ -16,12 +24,16 @@ library CoreRelayerLibrary {
         cu.module = encodedUpgrade.toBytes32(index);
         index += 32;
 
-        require(cu.module == module, "wrong module");
+        if (cu.module != module) {
+            revert WrongModule(cu.module);
+        }
 
         cu.action = encodedUpgrade.toUint8(index);
         index += 1;
 
-        require(cu.action == 1, "invalid ContractUpgrade");
+        if (cu.action != 1) {
+            revert InvalidContractUpgradeAction(cu.action);
+        }
 
         cu.chain = encodedUpgrade.toUint16(index);
         index += 2;
@@ -29,7 +41,9 @@ library CoreRelayerLibrary {
         cu.newContract = address(uint160(uint256(encodedUpgrade.toBytes32(index))));
         index += 32;
 
-        require(encodedUpgrade.length == index, "invalid ContractUpgrade");
+        if (encodedUpgrade.length != index) {
+            revert InvalidContractUpgradeLength(encodedUpgrade.length);
+        }
     }
 
     function parseRegisterChain(bytes memory encodedRegistration, bytes32 module)
@@ -42,7 +56,9 @@ library CoreRelayerLibrary {
         registerChain.module = encodedRegistration.toBytes32(index);
         index += 32;
 
-        require(registerChain.module == module, "wrong module");
+        if (registerChain.module != module) {
+            revert WrongModule(registerChain.module);
+        }
 
         registerChain.action = encodedRegistration.toUint8(index);
         index += 1;
@@ -50,7 +66,9 @@ library CoreRelayerLibrary {
         registerChain.chain = encodedRegistration.toUint16(index);
         index += 2;
 
-        require(registerChain.action == 2, "invalid RegisterChain");
+        if (registerChain.action != 2) {
+            revert InvalidRegisterChainAction(registerChain.action);
+        }
 
         registerChain.emitterChain = encodedRegistration.toUint16(index);
         index += 2;
@@ -58,7 +76,9 @@ library CoreRelayerLibrary {
         registerChain.emitterAddress = encodedRegistration.toBytes32(index);
         index += 32;
 
-        require(encodedRegistration.length == index, "invalid RegisterChain");
+        if (encodedRegistration.length != index) {
+            revert InvalidRegisterChainLength(encodedRegistration.length);
+        }
     }
 
     function parseUpdateDefaultProvider(bytes memory encodedDefaultProvider, bytes32 module)
@@ -71,12 +91,16 @@ library CoreRelayerLibrary {
         defaultProvider.module = encodedDefaultProvider.toBytes32(index);
         index += 32;
 
-        require(defaultProvider.module == module, "wrong module");
+        if (defaultProvider.module != module) {
+            revert WrongModule(defaultProvider.module);
+        }
 
         defaultProvider.action = encodedDefaultProvider.toUint8(index);
         index += 1;
 
-        require(defaultProvider.action == 3, "invalid DefaultProvider");
+        if (defaultProvider.action != 3) {
+            revert InvalidDefaultProviderAction(defaultProvider.action);
+        }
 
         defaultProvider.chain = encodedDefaultProvider.toUint16(index);
         index += 2;
@@ -84,7 +108,9 @@ library CoreRelayerLibrary {
         defaultProvider.newProvider = address(uint160(uint256(encodedDefaultProvider.toBytes32(index))));
         index += 32;
 
-        require(encodedDefaultProvider.length == index, "invalid DefaultProvider");
+        if (encodedDefaultProvider.length != index) {
+            revert InvalidDefaultProviderLength(encodedDefaultProvider.length);
+        }
     }
 
     struct ContractUpgrade {

--- a/ethereum/contracts/coreRelayer/CoreRelayerMessages.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerMessages.sol
@@ -11,6 +11,10 @@ import "./CoreRelayerStructs.sol";
 contract CoreRelayerMessages is CoreRelayerStructs, CoreRelayerGetters {
     using BytesLib for bytes;
 
+    error InvalidPayloadId(uint8 payloadId);
+    error InvalidDeliveryInstructionsPayload(uint256 length);
+    error InvalidDeliveryRequestsPayload(uint256 length);
+
     function decodeRedeliveryByTxHashInstruction(bytes memory encoded)
         internal
         pure
@@ -57,7 +61,9 @@ contract CoreRelayerMessages is CoreRelayerStructs, CoreRelayerGetters {
         uint256 index = 0;
 
         uint8 payloadId = encoded.toUint8(index);
-        require(payloadId == 1, "invalid payloadId");
+        if (payloadId != 1) {
+            revert InvalidPayloadId(payloadId);
+        }
         index += 1;
         bool sufficientlyFunded = encoded.toUint8(index) == 1;
         index += 1;
@@ -99,7 +105,9 @@ contract CoreRelayerMessages is CoreRelayerStructs, CoreRelayerGetters {
             instructionArray[i] = instruction;
         }
 
-        require(index == encoded.length, "invalid delivery instructions payload");
+        if (index != encoded.length) {
+            revert InvalidDeliveryInstructionsPayload(encoded.length);
+        }
 
         return DeliveryInstructionsContainer(payloadId, sufficientlyFunded, instructionArray);
     }
@@ -140,7 +148,9 @@ contract CoreRelayerMessages is CoreRelayerStructs, CoreRelayerGetters {
         uint256 index = 0;
 
         uint8 payloadId = encoded.toUint8(index);
-        require(payloadId == 1, "invalid payloadId");
+        if (payloadId != 1) {
+            revert InvalidPayloadId(payloadId);
+        }
         index += 1;
         address relayProviderAddress = encoded.toAddress(index);
         index += 20;
@@ -181,7 +191,9 @@ contract CoreRelayerMessages is CoreRelayerStructs, CoreRelayerGetters {
             requestArray[i] = request;
         }
 
-        require(index == encoded.length, "invalid delivery requests payload");
+        if (index != encoded.length) {
+            revert InvalidDeliveryRequestsPayload(encoded.length);
+        }
 
         return DeliveryRequestsContainer(payloadId, relayProviderAddress, requestArray);
     }

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "./CoreRelayerStructs.sol";
 
 contract CoreRelayerSetters is CoreRelayerState, Context {
-
     error InvalidEvmChainId();
 
     function setInitialized(address implementation) internal {

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
@@ -8,6 +8,9 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "./CoreRelayerStructs.sol";
 
 contract CoreRelayerSetters is CoreRelayerState, Context {
+
+    error InvalidEvmChainId();
+
     function setInitialized(address implementation) internal {
         _state.initializedImplementations[implementation] = true;
     }
@@ -57,7 +60,9 @@ contract CoreRelayerSetters is CoreRelayerState, Context {
     }
 
     function setEvmChainId(uint256 evmChainId) internal {
-        require(evmChainId == block.chainid, "invalid evmChainId ");
+        if (evmChainId != block.chainid) {
+            revert InvalidEvmChainId();
+        }
         _state.evmChainId = evmChainId;
     }
 }

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -8,7 +8,6 @@ import "./CoreRelayerGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
-
     error ImplementationAddressIsZero();
     error WormholeAddressIsZero();
     error DefaultRelayProviderAddressIsZero();

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -8,6 +8,12 @@ import "./CoreRelayerGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
+
+    error ImplementationAddressIsZero();
+    error WormholeAddressIsZero();
+    error DefaultRelayProviderAddressIsZero();
+    error FailedToInitializeImplementation(string reason);
+
     function setup(
         address implementation,
         uint16 chainId,
@@ -18,9 +24,15 @@ contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
         uint256 evmChainId
     ) public {
         // sanity check initial values
-        require(implementation != address(0), "1"); //"implementation cannot be address(0)");
-        require(wormhole != address(0), "2"); //wormhole cannot be address(0)");
-        require(defaultRelayProvider != address(0), "3"); //default relay provider cannot be address(0)");
+        if (implementation == address(0)) {
+            revert ImplementationAddressIsZero();
+        }
+        if (wormhole == address(0)) {
+            revert WormholeAddressIsZero();
+        }
+        if (defaultRelayProvider == address(0)) {
+            revert DefaultRelayProviderAddressIsZero();
+        }
 
         setChainId(chainId);
 
@@ -38,6 +50,8 @@ contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
 
         // call initialize function of the new implementation
         (bool success, bytes memory reason) = implementation.delegatecall(abi.encodeWithSignature("initialize()"));
-        require(success, string(reason));
+        if (!success) {
+            revert FailedToInitializeImplementation(string(reason));
+        }
     }
 }

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -9,7 +9,6 @@ import "../interfaces/IRelayProvider.sol";
 import "../interfaces/ICoreRelayer.sol";
 
 contract RelayProvider is RelayProviderGovernance, IRelayProvider {
-
     error CallerNotApproved(address msgSender);
 
     modifier onlyApprovedSender() {

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -9,8 +9,13 @@ import "../interfaces/IRelayProvider.sol";
 import "../interfaces/ICoreRelayer.sol";
 
 contract RelayProvider is RelayProviderGovernance, IRelayProvider {
+
+    error CallerNotApproved(address msgSender);
+
     modifier onlyApprovedSender() {
-        require(approvedSender(_msgSender()), "_msgSender() not approved");
+        if (!approvedSender(_msgSender())) {
+            revert CallerNotApproved(_msgSender());
+        }
         _;
     }
 

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -15,7 +15,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
 
     error ChainIdIsZero();
     error GasPriceIsZero();
-    error NativeCurrencyIsZero();
+    error NativeCurrencyPriceIsZero();
     error FailedToInitializeImplementation(string reason);
     error WrongChainId();
     error AddressIsZero();
@@ -71,7 +71,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
             revert GasPriceIsZero();
         }
         if (updateNativeCurrencyPrice == 0) {
-            revert NativeCurrencyIsZero();
+            revert NativeCurrencyPriceIsZero();
         }
 
         setPriceInfo(updateChainId, updateGasPrice, updateNativeCurrencyPrice);

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -12,7 +12,6 @@ import "./RelayProviderSetters.sol";
 import "./RelayProviderStructs.sol";
 
 abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProviderSetters, ERC1967Upgrade {
-
     error ChainIdIsZero();
     error GasPriceIsZero();
     error NativeCurrencyPriceIsZero();

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -7,9 +7,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 import "./RelayProvider.sol";
 
-
 contract RelayProviderImplementation is RelayProvider {
-
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -7,7 +7,11 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 import "./RelayProvider.sol";
 
+
 contract RelayProviderImplementation is RelayProvider {
+
+    error ImplementationAlreadyInitialized();
+
     function initialize() public virtual initializer {
         // this function needs to be exposed for an upgrade to pass
     }
@@ -15,7 +19,9 @@ contract RelayProviderImplementation is RelayProvider {
     modifier initializer() {
         address impl = ERC1967Upgrade._getImplementation();
 
-        require(!isInitialized(impl), "already initialized");
+        if (isInitialized(impl)) {
+            revert ImplementationAlreadyInitialized();
+        }
 
         setInitialized(impl);
 

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -8,9 +8,15 @@ import "./RelayProviderGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
+
+    error ImplementationAddressIsZero();
+    error FailedToInitializeImplementation(string reason);
+
     function setup(address implementation, uint16 chainId) public {
         // sanity check initial values
-        require(implementation != address(0), "implementation cannot be address(0)");
+        if (implementation == address(0)) {
+            revert ImplementationAddressIsZero();
+        }
 
         setOwner(_msgSender());
 
@@ -20,6 +26,8 @@ contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
 
         // call initialize function of the new implementation
         (bool success, bytes memory reason) = implementation.delegatecall(abi.encodeWithSignature("initialize()"));
-        require(success, string(reason));
+        if (!success) {
+            revert FailedToInitializeImplementation(string(reason));
+        }
     }
 }

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -8,7 +8,6 @@ import "./RelayProviderGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
-
     error ImplementationAddressIsZero();
     error FailedToInitializeImplementation(string reason);
 

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -473,7 +473,7 @@ contract TestCoreRelayer is Test {
         uint256 computeBudget =
             source.coreRelayer.quoteGasDeliveryFee(TARGET_CHAIN_ID, gasParams.targetGasLimit, source.relayProvider);
 
-        vm.expectRevert(bytes("2"));
+        vm.expectRevert(abi.encodeWithSignature("NonceIsZero()"));
         source.integration.sendMessageGeneral{value: computeBudget + wormholeFee}(
             abi.encodePacked(uint8(0), message),
             TARGET_CHAIN_ID,
@@ -516,7 +516,7 @@ contract TestCoreRelayer is Test {
         }
     }
 
-    function testRevertRedeliveryErrors_1_9_10_11_12_13_14_15_16_17(
+    function testRevertRedeliveryErrors(
         GasParameters memory gasParams,
         bytes memory message
     ) public {
@@ -554,7 +554,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(bytes("1"));
+        vm.expectRevert(abi.encodeWithSignature("MsgValueTooLow()"));
         source.coreRelayer.requestRedelivery{value: stack.payment - 1}(stack.redeliveryRequest, 1, source.relayProvider);
 
         source.coreRelayer.requestRedelivery{value: stack.payment}(stack.redeliveryRequest, 1, source.relayProvider);
@@ -586,7 +586,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("9"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         stack.originalDelivery.encodedVMs[1] = stack.originalDelivery.encodedVMs[0];
@@ -599,7 +599,7 @@ contract TestCoreRelayer is Test {
         );
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("10"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidEmitterInOriginalDeliveryVM()"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         stack.originalDelivery.encodedVMs[1] = correctVM;
@@ -623,7 +623,7 @@ contract TestCoreRelayer is Test {
         );
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("11"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)","VM signature invalid"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         fakeVM = relayerWormholeSimulator.fetchSignedMessageFromLogs(
@@ -637,7 +637,7 @@ contract TestCoreRelayer is Test {
         );
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("12"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidEmitterInRedeliveryVM()"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         source.relayProvider.updateDeliveryAddress(TARGET_CHAIN_ID, bytes32(uint256(uint160(address(this)))));
@@ -657,7 +657,7 @@ contract TestCoreRelayer is Test {
         );
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("13"));
+        vm.expectRevert(abi.encodeWithSignature("MismatchingRelayProvidersInRedelivery()"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         stack.package = ICoreRelayer.TargetRedeliveryByTxHashParamsSingle(
@@ -667,7 +667,7 @@ contract TestCoreRelayer is Test {
             stack.originalDelivery.multisendIndex
         );
 
-        vm.expectRevert(bytes("14"));
+        vm.expectRevert(abi.encodeWithSignature("ProviderAddressIsNotSender()"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         uint16 differentChainId = 2;
@@ -676,7 +676,7 @@ contract TestCoreRelayer is Test {
         }
 
         vm.deal(map[differentChainId].relayer, stack.budget);
-        vm.expectRevert(bytes("15"));
+        vm.expectRevert(abi.encodeWithSignature("RedeliveryRequestDoesNotTargetThisChain()"));
         vm.prank(target.relayer);
         map[differentChainId].coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
@@ -709,7 +709,7 @@ contract TestCoreRelayer is Test {
             stack.originalDelivery.multisendIndex
         );
 
-        vm.expectRevert(bytes("16"));
+        vm.expectRevert(abi.encodeWithSignature("OriginalDeliveryRequestDidNotTargetThisChain()"));
         vm.prank(target.relayer);
         map[differentChainId].coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
@@ -720,7 +720,7 @@ contract TestCoreRelayer is Test {
             stack.originalDelivery.multisendIndex
         );
 
-        vm.expectRevert(bytes("17"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientRelayerFunds()"));
         vm.prank(target.relayer);
         target.coreRelayer.redeliverSingle{value: stack.budget - 1}(stack.package);
 
@@ -750,7 +750,7 @@ contract TestCoreRelayer is Test {
         ICoreRelayer.DeliveryInstruction instruction;
     }
 
-    function testRevertDeliveryErrors_18_19_20_21_22_23_24(GasParameters memory gasParams, bytes memory message)
+    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message)
         public
     {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
@@ -798,7 +798,7 @@ contract TestCoreRelayer is Test {
                 + target.wormhole.messageFee();
 
             vm.prank(source.relayer);
-            vm.expectRevert(bytes("20"));
+            vm.expectRevert(abi.encodeWithSignature("DeliveryRequestNotSufficientlyFunded()"));
             source.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
         }
 
@@ -846,7 +846,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("18"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         stack.encodedVMs[1] = stack.encodedVMs[0];
@@ -854,18 +854,18 @@ contract TestCoreRelayer is Test {
         stack.package = ICoreRelayer.TargetDeliveryParametersSingle(stack.encodedVMs, 1, 0);
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("19"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidEmitter()"));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         stack.encodedVMs[1] = stack.deliveryVM;
 
         stack.package = ICoreRelayer.TargetDeliveryParametersSingle(stack.encodedVMs, 1, 0);
 
-        vm.expectRevert(bytes("21"));
+        vm.expectRevert(abi.encodeWithSignature("UnexpectedRelayer()"));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("22"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientRelayerFunds()"));
         target.coreRelayer.deliverSingle{value: stack.budget - 1}(stack.package);
 
         uint16 differentChainId = 2;
@@ -874,14 +874,14 @@ contract TestCoreRelayer is Test {
         }
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("24"));
+        vm.expectRevert(abi.encodeWithSignature("TargetChainIsNotThisChain(uint16)", 2));
         map[differentChainId].coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         vm.prank(target.relayer);
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         vm.prank(target.relayer);
-        vm.expectRevert(bytes("23"));
+        vm.expectRevert(abi.encodeWithSignature("AlreadyDelivered()"));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
     }
 
@@ -895,7 +895,7 @@ contract TestCoreRelayer is Test {
      * Request delivery 25-27
      */
 
-    function testRevertRequestDeliveryErrors_25_26_27(GasParameters memory gasParams, bytes memory message) public {
+    function testRevertRequestDeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -919,7 +919,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(bytes("25"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","25"));
         source.coreRelayer.requestDelivery{value: stack.payment - 1}(stack.deliveryRequest, 1, source.relayProvider);
 
         source.relayProvider.updateDeliverGasOverhead(TARGET_CHAIN_ID, gasParams.evmGasOverhead);
@@ -936,7 +936,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(bytes("26"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","26"));
         source.coreRelayer.requestDelivery{value: stack.deliveryOverhead - 1}(
             stack.badDeliveryRequest, 1, source.relayProvider
         );
@@ -947,7 +947,7 @@ contract TestCoreRelayer is Test {
             TARGET_CHAIN_ID, uint256(gasParams.targetGasLimit - 1) * gasParams.targetGasPrice
         );
 
-        vm.expectRevert(bytes("27"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","27"));
         source.coreRelayer.requestDelivery{value: stack.payment}(stack.deliveryRequest, 1, source.relayProvider);
     }
 

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -516,10 +516,7 @@ contract TestCoreRelayer is Test {
         }
     }
 
-    function testRevertRedeliveryErrors(
-        GasParameters memory gasParams,
-        bytes memory message
-    ) public {
+    function testRevertRedeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -586,7 +583,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)", 1));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         stack.originalDelivery.encodedVMs[1] = stack.originalDelivery.encodedVMs[0];
@@ -623,7 +620,7 @@ contract TestCoreRelayer is Test {
         );
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)","VM signature invalid"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)", "VM signature invalid"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         fakeVM = relayerWormholeSimulator.fetchSignedMessageFromLogs(
@@ -750,9 +747,7 @@ contract TestCoreRelayer is Test {
         ICoreRelayer.DeliveryInstruction instruction;
     }
 
-    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message)
-        public
-    {
+    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -846,7 +841,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)", 1));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         stack.encodedVMs[1] = stack.encodedVMs[0];
@@ -919,7 +914,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","25"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "25"));
         source.coreRelayer.requestDelivery{value: stack.payment - 1}(stack.deliveryRequest, 1, source.relayProvider);
 
         source.relayProvider.updateDeliverGasOverhead(TARGET_CHAIN_ID, gasParams.evmGasOverhead);
@@ -936,7 +931,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","26"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "26"));
         source.coreRelayer.requestDelivery{value: stack.deliveryOverhead - 1}(
             stack.badDeliveryRequest, 1, source.relayProvider
         );
@@ -947,7 +942,7 @@ contract TestCoreRelayer is Test {
             TARGET_CHAIN_ID, uint256(gasParams.targetGasLimit - 1) * gasParams.targetGasPrice
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","27"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "27"));
         source.coreRelayer.requestDelivery{value: stack.payment}(stack.deliveryRequest, 1, source.relayProvider);
     }
 

--- a/ethereum/forge-test/RelayProvider.t.sol
+++ b/ethereum/forge-test/RelayProvider.t.sol
@@ -42,7 +42,7 @@ contract TestRelayProvider is Test {
         initializeRelayProvider();
 
         // you shall not pass
-        vm.expectRevert("updateChainId == 0");
+        vm.expectRevert(abi.encodeWithSignature("ChainIdIsZero()"));
         relayProvider.updatePrice(
             0, // updateChainId
             updateGasPrice,
@@ -57,7 +57,7 @@ contract TestRelayProvider is Test {
         initializeRelayProvider();
 
         // you shall not pass
-        vm.expectRevert("updateGasPrice == 0");
+        vm.expectRevert(abi.encodeWithSignature("GasPriceIsZero()"));
         relayProvider.updatePrice(
             updateChainId,
             0, // updateGasPrice == 0
@@ -72,7 +72,7 @@ contract TestRelayProvider is Test {
         initializeRelayProvider();
 
         // you shall not pass
-        vm.expectRevert("updateNativeCurrencyPrice == 0");
+        vm.expectRevert(abi.encodeWithSignature("NativeCurrencyPriceIsZero()"));
         relayProvider.updatePrice(
             updateChainId,
             updateGasPrice,
@@ -96,7 +96,7 @@ contract TestRelayProvider is Test {
 
         // you shall not pass
         vm.prank(oracleOwner);
-        vm.expectRevert("owner() != _msgSender()");
+        vm.expectRevert(abi.encodeWithSignature("CallerMustBeOwner()"));
         relayProvider.updatePrice(updateChainId, updateGasPrice, updateNativeCurrencyPrice);
     }
 


### PR DESCRIPTION
### Summary

This pull request replaces calls to `require()` with typed errors.

Favored longer identifier names for error types, with the objective of making them more descriptive.
