### PR TITLE
Increase NatSpec documentation coverage

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -536,7 +536,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         if (!valid) {
             revert InvalidRedeliveryVM(reason);
         }
-        if(!verifyRelayerVM(redeliveryVM)) {
+        if (!verifyRelayerVM(redeliveryVM)) {
             // Redelivery VM has an invalid emitter
             revert InvalidEmitterInRedeliveryVM();
         }
@@ -547,7 +547,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         );
 
         //redelivery request cannot have already been attempted
-        if (isDeliveryCompleted(redeliveryVM.hash)){
+        if (isDeliveryCompleted(redeliveryVM.hash)) {
             revert AlreadyDelivered();
         }
 
@@ -565,20 +565,17 @@ contract CoreRelayer is CoreRelayerGovernance {
 
         // The same relay provider must be specified when doing a single VAA redeliver.
         address providerAddress = fromWormholeFormat(redeliveryInstruction.executionParameters.providerDeliveryAddress);
-        if (
-            providerAddress != fromWormholeFormat(originalInstruction.executionParameters.providerDeliveryAddress)
-        ) {
+        if (providerAddress != fromWormholeFormat(originalInstruction.executionParameters.providerDeliveryAddress)) {
             revert MismatchingRelayProvidersInRedelivery();
         }
 
-
         // msg.sender must be the provider
-        if(msg.sender != providerAddress) {
+        if (msg.sender != providerAddress) {
             revert ProviderAddressIsNotSender();
         }
 
         //redelivery must target this chain
-        if(chainId() != redeliveryInstruction.targetChain) {
+        if (chainId() != redeliveryInstruction.targetChain) {
             revert RedeliveryRequestDoesNotTargetThisChain();
         }
 
@@ -588,8 +585,10 @@ contract CoreRelayer is CoreRelayerGovernance {
         }
 
         //relayer must have covered the necessary funds
-        if ( msg.value <
-                redeliveryInstruction.newMaximumRefundTarget + redeliveryInstruction.newApplicationBudgetTarget + wormhole().messageFee()
+        if (
+            msg.value
+                < redeliveryInstruction.newMaximumRefundTarget + redeliveryInstruction.newApplicationBudgetTarget
+                    + wormhole().messageFee()
         ) {
             revert InsufficientRelayerFunds();
         }
@@ -615,13 +614,13 @@ contract CoreRelayer is CoreRelayerGovernance {
         if (!valid) {
             revert InvalidVaa(targetParams.deliveryIndex);
         }
-        if(!verifyRelayerVM(deliveryVM)) {
+        if (!verifyRelayerVM(deliveryVM)) {
             revert InvalidEmitter();
         }
 
         DeliveryInstructionsContainer memory container = decodeDeliveryInstructionsContainer(deliveryVM.payload);
         //ensure this is a funded delivery, not a failed forward.
-        if(!container.sufficientlyFunded) {
+        if (!container.sufficientlyFunded) {
             revert DeliveryRequestNotSufficientlyFunded();
         }
 
@@ -629,13 +628,15 @@ contract CoreRelayer is CoreRelayerGovernance {
         DeliveryInstruction memory deliveryInstruction = container.instructions[targetParams.multisendIndex];
 
         //make sure the specified relayer is the relayer delivering this message
-        if(fromWormholeFormat(deliveryInstruction.executionParameters.providerDeliveryAddress) != msg.sender) {
+        if (fromWormholeFormat(deliveryInstruction.executionParameters.providerDeliveryAddress) != msg.sender) {
             revert UnexpectedRelayer();
         }
 
         //make sure relayer passed in sufficient funds
-        if (msg.value <
-            deliveryInstruction.maximumRefundTarget + deliveryInstruction.applicationBudgetTarget + wormhole.messageFee()
+        if (
+            msg.value
+                < deliveryInstruction.maximumRefundTarget + deliveryInstruction.applicationBudgetTarget
+                    + wormhole.messageFee()
         ) {
             revert InsufficientRelayerFunds();
         }

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -11,28 +11,46 @@ import "./CoreRelayerStructs.sol";
 contract CoreRelayer is CoreRelayerGovernance {
     using BytesLib for bytes;
 
+    /// @notice msg.value was too low.
+    /// @param reason An internal error code that further identifies the cause of failure.
     error InsufficientFunds(string reason);
-    error MsgValueTooLow(); // msg.value must cover the budget specified
+    /// @notice msg.value must cover the budget specified.
+    error MsgValueTooLow();
     error NonceIsZero();
     error NoDeliveryInProcess();
     error CantRequestMultipleForwards();
     error RelayProviderDoesNotSupportTargetChain();
-    error RolloverChainNotIncluded(); // Rollover chain was not included in the forwarding request
-    error ChainNotFoundInDeliveryRequests(uint16 chainId); // Required chain not found in the delivery requests
+    /// @notice Rollover chain was not included in the forwarding request.
+    error RolloverChainNotIncluded();
+    /// @notice Required chain not found in the delivery requests.
+    /// @param chainId the required chain ID.
+    error ChainNotFoundInDeliveryRequests(uint16 chainId);
     error ReentrantCall();
     error InvalidEmitterInOriginalDeliveryVM();
+    /// @notice Tried to redeliver a VM that is invalid.
+    /// @param reason An error string further detailing the reason why the VM is invalid.
     error InvalidRedeliveryVM(string reason);
     error InvalidEmitterInRedeliveryVM();
-    error MismatchingRelayProvidersInRedelivery(); // The same relay provider must be specified when doing a single VAA redeliver
-    error ProviderAddressIsNotSender(); // msg.sender must be the provider
+    /// @notice The same relay provider must be specified when doing a single VAA redeliver.
+    error MismatchingRelayProvidersInRedelivery();
+    /// @notice msg.sender must be the provider.
+    error ProviderAddressIsNotSender();
     error RedeliveryRequestDoesNotTargetThisChain();
     error OriginalDeliveryRequestDidNotTargetThisChain();
-    error InvalidVaa(uint256 deliveryIndex); // Invalid VAA at delivery index
+    /// @notice Invalid VAA at delivery index.
+    /// @param deliveryIndex the delivery index at which the invalid VAA was found.
+    error InvalidVaa(uint256 deliveryIndex);
     error InvalidEmitter();
-    error DeliveryRequestNotSufficientlyFunded(); // This delivery request was not sufficiently funded, and must request redelivery
-    error UnexpectedRelayer(); // Specified relayer is not the relayer delivering the message
-    error InsufficientRelayerFunds(); // The relayer didn't pass sufficient funds (msg.value does not cover the necessary budget fees)
-    error AlreadyDelivered(); // The message was already delivered.
+    /// @notice This delivery request was not sufficiently funded, and must request redelivery.
+    error DeliveryRequestNotSufficientlyFunded();
+    /// @notice Specified relayer is not the relayer delivering the message.
+    error UnexpectedRelayer();
+    /// @notice The relayer didn't pass sufficient funds (msg.value does not cover the necessary budget fees).
+    error InsufficientRelayerFunds();
+    /// @notice The message was already delivered.
+    error AlreadyDelivered();
+    /// @notice The destination chain is not this chain.
+    /// @param targetChainId the destination chain ID found in the message.
     error TargetChainIsNotThisChain(uint16 targetChainId);
     error SrcNativeCurrencyPriceIsZero();
     error DstNativeCurrencyPriceIsZero();

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -12,7 +12,7 @@ contract CoreRelayer is CoreRelayerGovernance {
     using BytesLib for bytes;
 
     error InsufficientFunds(string reason);
-    error MsgValueTooLow(uint256 expectedValue); // msg.value must be equal or greater than `expectedValue`
+    error MsgValueTooLow(); // msg.value must cover the budget specified
     error NonceIsZero();
     error NoDeliveryInProcess();
     error CantRequestMultipleForwards();
@@ -31,8 +31,8 @@ contract CoreRelayer is CoreRelayerGovernance {
     error InvalidEmitter();
     error DeliveryRequestNotSufficientlyFunded(); // This delivery request was not sufficiently funded, and must request redelivery
     error UnexpectedRelayer(); // Specified relayer is not the relayer delivering the message
-    error InsufficientRelayerFunds(uint256 expectedFunds); // The relayer didn't pass sufficient funds (msg.value does not cover the necessary budget fees)
-    error AlreadyDelivered(bytes32 hash); // The message was already delivered.
+    error InsufficientRelayerFunds(); // The relayer didn't pass sufficient funds (msg.value does not cover the necessary budget fees)
+    error AlreadyDelivered(); // The message was already delivered.
     error TargetChainIsNotThisChain(uint16 targetChainId);
     error SrcNativeCurrencyPriceIsZero();
     error DstNativeCurrencyPriceIsZero();
@@ -94,7 +94,7 @@ contract CoreRelayer is CoreRelayerGovernance {
 
         //Make sure the msg.value covers the budget they specified
         if (msg.value < totalFee) {
-            revert MsgValueTooLow(totalFee);
+            revert MsgValueTooLow();
         }
 
         emitRedelivery(request, nonce, provider.getConsistencyLevel(), applicationBudgetTarget, maximumRefund, provider);
@@ -548,7 +548,7 @@ contract CoreRelayer is CoreRelayerGovernance {
 
         //redelivery request cannot have already been attempted
         if (isDeliveryCompleted(redeliveryVM.hash)){
-            revert AlreadyDelivered(redeliveryVM.hash);
+            revert AlreadyDelivered();
         }
 
         //mark redelivery as attempted
@@ -591,7 +591,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         if ( msg.value <
                 redeliveryInstruction.newMaximumRefundTarget + redeliveryInstruction.newApplicationBudgetTarget + wormhole().messageFee()
         ) {
-            revert InsufficientRelayerFunds(redeliveryInstruction.newMaximumRefundTarget + redeliveryInstruction.newApplicationBudgetTarget + wormhole().messageFee());
+            revert InsufficientRelayerFunds();
         }
 
         //Overwrite compute budget and application budget on the original request and proceed.
@@ -637,12 +637,12 @@ contract CoreRelayer is CoreRelayerGovernance {
         if (msg.value <
             deliveryInstruction.maximumRefundTarget + deliveryInstruction.applicationBudgetTarget + wormhole.messageFee()
         ) {
-            revert InsufficientRelayerFunds(deliveryInstruction.maximumRefundTarget + deliveryInstruction.applicationBudgetTarget + wormhole.messageFee());
+            revert InsufficientRelayerFunds();
         }
 
         //make sure this has not already been delivered
         if (isDeliveryCompleted(deliveryVM.hash)) {
-            revert AlreadyDelivered(deliveryVM.hash);
+            revert AlreadyDelivered();
         }
 
         //mark as delivered, so it can't be reattempted

--- a/ethereum/contracts/coreRelayer/CoreRelayerGovernance.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerGovernance.sol
@@ -23,10 +23,16 @@ abstract contract CoreRelayerGovernance is
 {
     using BytesLib for bytes;
 
+    /// @notice evmChainId in state does not match block.chainid
     error InvalidFork();
+    /// @notice Verification of the GovernanceVM failed.
+    /// @param reason A string further specifying the cause why the GovernanceVM is invalid.
     error InvalidGovernanceVM(string reason);
-    error WrongChainId(uint16 chainId);
+    /// @notice Encountered an unexpected chainId in governance message.
+    /// @param chainId The unexpected chain ID found in the message.
     error InvalidChainId(uint16 chainId);
+    /// @notice Failed to initialize the proxy implementation.
+    /// @param reason A string that further identifies the cause of failure.
     error FailedToInitializeImplementation(string reason);
 
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
@@ -48,7 +54,7 @@ abstract contract CoreRelayerGovernance is
 
         CoreRelayerLibrary.ContractUpgrade memory contractUpgrade = CoreRelayerLibrary.parseUpgrade(vm.payload, module);
         if (contractUpgrade.chain != chainId()) {
-            revert WrongChainId(contractUpgrade.chain);
+            revert InvalidChainId(contractUpgrade.chain);
         }
 
         upgradeImplementation(contractUpgrade.newContract);

--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./CoreRelayer.sol";
 
 contract CoreRelayerImplementation is CoreRelayer {
-
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./CoreRelayer.sol";
 
 contract CoreRelayerImplementation is CoreRelayer {
+
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./CoreRelayer.sol";
 
 contract CoreRelayerImplementation is CoreRelayer {
-
     /// @notice The proxy implementation is already initialized.
     error ImplementationAlreadyInitialized();
 

--- a/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerImplementation.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./CoreRelayer.sol";
 
 contract CoreRelayerImplementation is CoreRelayer {
+
+    /// @notice The proxy implementation is already initialized.
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/coreRelayer/CoreRelayerLibrary.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerLibrary.sol
@@ -6,12 +6,19 @@ import "../libraries/external/BytesLib.sol";
 library CoreRelayerLibrary {
     using BytesLib for bytes;
 
-    error WrongModule(bytes32 module);
+    /// @notice Encountered unexpected module while parsing.
+    error UnexpectedModule(bytes32 module);
+    /// @notice Encountered an invalid action while parsing an encoded upgrade.
     error InvalidContractUpgradeAction(uint8 action);
+    /// @notice Encoded upgrade has an invalid length.
     error InvalidContractUpgradeLength(uint256 length);
+    /// @notice Encountered an invalid action while parsing an encoded registration.
     error InvalidRegisterChainAction(uint8);
+    /// @notice Encoded registration has an invalid length.
     error InvalidRegisterChainLength(uint256);
+    /// @notice Encountered an invalid action while parsing encoded default provider.
     error InvalidDefaultProviderAction(uint8);
+    /// @notice Encoded default provider has an invalid length.
     error InvalidDefaultProviderLength(uint256);
 
     function parseUpgrade(bytes memory encodedUpgrade, bytes32 module)
@@ -25,7 +32,7 @@ library CoreRelayerLibrary {
         index += 32;
 
         if (cu.module != module) {
-            revert WrongModule(cu.module);
+            revert UnexpectedModule(cu.module);
         }
 
         cu.action = encodedUpgrade.toUint8(index);
@@ -57,7 +64,7 @@ library CoreRelayerLibrary {
         index += 32;
 
         if (registerChain.module != module) {
-            revert WrongModule(registerChain.module);
+            revert UnexpectedModule(registerChain.module);
         }
 
         registerChain.action = encodedRegistration.toUint8(index);
@@ -92,7 +99,7 @@ library CoreRelayerLibrary {
         index += 32;
 
         if (defaultProvider.module != module) {
-            revert WrongModule(defaultProvider.module);
+            revert UnexpectedModule(defaultProvider.module);
         }
 
         defaultProvider.action = encodedDefaultProvider.toUint8(index);

--- a/ethereum/contracts/coreRelayer/CoreRelayerMessages.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerMessages.sol
@@ -11,8 +11,14 @@ import "./CoreRelayerStructs.sol";
 contract CoreRelayerMessages is CoreRelayerStructs, CoreRelayerGetters {
     using BytesLib for bytes;
 
+    /// @notice Unexpected payloadId found in delivery instructions.
+    /// @param payloadId The payload ID found in the delivery instructions container.
     error InvalidPayloadId(uint8 payloadId);
+    /// @notice Delivery instructions payload has an invalid length.
+    /// @param length The size in bytes of the delivery instructions.
     error InvalidDeliveryInstructionsPayload(uint256 length);
+    /// @notice Delivery requests payload has an invalid length.
+    /// @param length The size in bytes of the delivery requests.
     error InvalidDeliveryRequestsPayload(uint256 length);
 
     function decodeRedeliveryByTxHashInstruction(bytes memory encoded)

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "./CoreRelayerStructs.sol";
 
 contract CoreRelayerSetters is CoreRelayerState, Context {
+
+    /// @notice The evmChainId provided doesn't match block.chainid
     error InvalidEvmChainId();
 
     function setInitialized(address implementation) internal {

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "./CoreRelayerStructs.sol";
 
 contract CoreRelayerSetters is CoreRelayerState, Context {
-
     /// @notice The evmChainId provided doesn't match block.chainid
     error InvalidEvmChainId();
 

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "./CoreRelayerStructs.sol";
 
 contract CoreRelayerSetters is CoreRelayerState, Context {
-
     error InvalidEvmChainId();
 
     function setInitialized(address implementation) internal {

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetters.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "./CoreRelayerStructs.sol";
 
 contract CoreRelayerSetters is CoreRelayerState, Context {
+
     error InvalidEvmChainId();
 
     function setInitialized(address implementation) internal {

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -8,7 +8,6 @@ import "./CoreRelayerGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
-
     /// @notice Attempted to initialize the proxy implementation address to 0
     error ImplementationAddressIsZero();
     /// @notice Attempted to initialize the wormhole contract address to 0

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -8,9 +8,15 @@ import "./CoreRelayerGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
+
+    /// @notice Attempted to initialize the proxy implementation address to 0
     error ImplementationAddressIsZero();
+    /// @notice Attempted to initialize the wormhole contract address to 0
     error WormholeAddressIsZero();
+    /// @notice Attempted to initialize the default relay provider address to 0
     error DefaultRelayProviderAddressIsZero();
+    /// @notice Failed to initialize the proxy implementation.
+    /// @param reason A string that further specifies the reason for the failure.
     error FailedToInitializeImplementation(string reason);
 
     function setup(

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -8,6 +8,7 @@ import "./CoreRelayerGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
+
     error ImplementationAddressIsZero();
     error WormholeAddressIsZero();
     error DefaultRelayProviderAddressIsZero();

--- a/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayerSetup.sol
@@ -8,7 +8,6 @@ import "./CoreRelayerGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract CoreRelayerSetup is CoreRelayerSetters, ERC1967Upgrade {
-
     error ImplementationAddressIsZero();
     error WormholeAddressIsZero();
     error DefaultRelayProviderAddressIsZero();

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -9,7 +9,6 @@ import "../interfaces/IRelayProvider.sol";
 import "../interfaces/ICoreRelayer.sol";
 
 contract RelayProvider is RelayProviderGovernance, IRelayProvider {
-
     error CallerNotApproved(address msgSender);
 
     modifier onlyApprovedSender() {

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -9,6 +9,9 @@ import "../interfaces/IRelayProvider.sol";
 import "../interfaces/ICoreRelayer.sol";
 
 contract RelayProvider is RelayProviderGovernance, IRelayProvider {
+
+    /// @notice The caller is not an approved address.
+    /// @param msgSender The caller address that triggered this error.
     error CallerNotApproved(address msgSender);
 
     modifier onlyApprovedSender() {

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -9,7 +9,6 @@ import "../interfaces/IRelayProvider.sol";
 import "../interfaces/ICoreRelayer.sol";
 
 contract RelayProvider is RelayProviderGovernance, IRelayProvider {
-
     /// @notice The caller is not an approved address.
     /// @param msgSender The caller address that triggered this error.
     error CallerNotApproved(address msgSender);

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -9,6 +9,7 @@ import "../interfaces/IRelayProvider.sol";
 import "../interfaces/ICoreRelayer.sol";
 
 contract RelayProvider is RelayProviderGovernance, IRelayProvider {
+
     error CallerNotApproved(address msgSender);
 
     modifier onlyApprovedSender() {

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -12,7 +12,6 @@ import "./RelayProviderSetters.sol";
 import "./RelayProviderStructs.sol";
 
 abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProviderSetters, ERC1967Upgrade {
-
     /// Attempted to call function updatePrice with updateChainId=0.
     error ChainIdIsZero();
     /// Attempted to call function updatePrice with updateGasPrice=0.

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -12,13 +12,23 @@ import "./RelayProviderSetters.sol";
 import "./RelayProviderStructs.sol";
 
 abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProviderSetters, ERC1967Upgrade {
+
+    /// Attempted to call function updatePrice with updateChainId=0.
     error ChainIdIsZero();
+    /// Attempted to call function updatePrice with updateGasPrice=0.
     error GasPriceIsZero();
+    /// Attempted to call function updatePrice with updateNativeCurrencyPrice=0.
     error NativeCurrencyPriceIsZero();
+    /// @notice Failed to initialize the implementation behind the proxy.
+    /// @param reason An error string further specifying the details of the failure.
     error FailedToInitializeImplementation(string reason);
+    /// @notice Input chainId is different from the current chain.
     error WrongChainId();
-    error AddressIsZero();
+    /// @notice The new owner can't be the zero address.
+    error NewOwnerAddressIsZero();
+    /// @notice In order to call the function confirmOwnershipTransferRequest, the sender must be a pending owner.
     error CallerMustBePendingOwner();
+    /// @notice Caller must be the owner address.
     error CallerMustBeOwner();
 
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
@@ -128,7 +138,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
             revert WrongChainId();
         }
         if (newOwner == address(0)) {
-            revert AddressIsZero();
+            revert NewOwnerAddressIsZero();
         }
 
         setPendingOwner(newOwner);

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -12,9 +12,10 @@ import "./RelayProviderSetters.sol";
 import "./RelayProviderStructs.sol";
 
 abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProviderSetters, ERC1967Upgrade {
+
     error ChainIdIsZero();
     error GasPriceIsZero();
-    error NativeCurrencyPriceIsZero();
+    error NativeCurrencyIsZero();
     error FailedToInitializeImplementation(string reason);
     error WrongChainId();
     error AddressIsZero();
@@ -71,7 +72,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
             revert GasPriceIsZero();
         }
         if (updateNativeCurrencyPrice == 0) {
-            revert NativeCurrencyPriceIsZero();
+            revert NativeCurrencyIsZero();
         }
 
         setPriceInfo(updateChainId, updateGasPrice, updateNativeCurrencyPrice);

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -15,7 +15,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
 
     error ChainIdIsZero();
     error GasPriceIsZero();
-    error NativeCurrencyIsZero();
+    error NativeCurrencyPriceIsZero();
     error FailedToInitializeImplementation(string reason);
     error WrongChainId();
     error AddressIsZero();
@@ -72,7 +72,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
             revert GasPriceIsZero();
         }
         if (updateNativeCurrencyPrice == 0) {
-            revert NativeCurrencyIsZero();
+            revert NativeCurrencyPriceIsZero();
         }
 
         setPriceInfo(updateChainId, updateGasPrice, updateNativeCurrencyPrice);

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -12,7 +12,6 @@ import "./RelayProviderSetters.sol";
 import "./RelayProviderStructs.sol";
 
 abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProviderSetters, ERC1967Upgrade {
-
     error ChainIdIsZero();
     error GasPriceIsZero();
     error NativeCurrencyPriceIsZero();

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -7,9 +7,7 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 import "./RelayProvider.sol";
 
-
 contract RelayProviderImplementation is RelayProvider {
-
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -8,7 +8,6 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./RelayProvider.sol";
 
 contract RelayProviderImplementation is RelayProvider {
-
     /// @notice The proxy implementation is already initialized.
     error ImplementationAlreadyInitialized();
 

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 import "./RelayProvider.sol";
 
 contract RelayProviderImplementation is RelayProvider {
+
+    /// @notice The proxy implementation is already initialized.
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderImplementation.sol
@@ -7,7 +7,9 @@ import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 import "./RelayProvider.sol";
 
+
 contract RelayProviderImplementation is RelayProvider {
+
     error ImplementationAlreadyInitialized();
 
     function initialize() public virtual initializer {

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -8,7 +8,11 @@ import "./RelayProviderGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
+
+    /// @notice Attempted to call function setup with implementation=address(0).
     error ImplementationAddressIsZero();
+    /// @notice Failed to initialize the implementation behind the proxy.
+    /// @param reason A string that further identifies the cause of failure.
     error FailedToInitializeImplementation(string reason);
 
     function setup(address implementation, uint16 chainId) public {

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -8,7 +8,6 @@ import "./RelayProviderGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
-
     error ImplementationAddressIsZero();
     error FailedToInitializeImplementation(string reason);
 

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -8,7 +8,6 @@ import "./RelayProviderGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
-
     /// @notice Attempted to call function setup with implementation=address(0).
     error ImplementationAddressIsZero();
     /// @notice Failed to initialize the implementation behind the proxy.

--- a/ethereum/contracts/relayProvider/RelayProviderSetup.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetup.sol
@@ -8,6 +8,7 @@ import "./RelayProviderGovernance.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
 
 contract RelayProviderSetup is RelayProviderSetters, ERC1967Upgrade {
+
     error ImplementationAddressIsZero();
     error FailedToInitializeImplementation(string reason);
 

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -560,10 +560,7 @@ contract TestCoreRelayer is Test {
         }
     }
 
-    function testRevertRedeliveryErrors(
-        GasParameters memory gasParams,
-        bytes memory message
-    ) public {
+    function testRevertRedeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -630,7 +627,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)", 1));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         stack.originalDelivery.encodedVMs[1] = stack.originalDelivery.encodedVMs[0];
@@ -667,7 +664,7 @@ contract TestCoreRelayer is Test {
         });
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)","VM signature invalid"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)", "VM signature invalid"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         fakeVM = relayerWormholeSimulator.fetchSignedMessageFromLogs(
@@ -794,9 +791,7 @@ contract TestCoreRelayer is Test {
         ICoreRelayer.DeliveryInstruction instruction;
     }
 
-    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message)
-        public
-    {
+    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -890,7 +885,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)", 1));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         stack.encodedVMs[1] = stack.encodedVMs[0];
@@ -963,7 +958,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","25"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "25"));
         source.coreRelayer.requestDelivery{value: stack.payment - 1}(stack.deliveryRequest, 1, source.relayProvider);
 
         source.relayProvider.updateDeliverGasOverhead(TARGET_CHAIN_ID, gasParams.evmGasOverhead);
@@ -980,7 +975,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","26"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "26"));
         source.coreRelayer.requestDelivery{value: stack.deliveryOverhead - 1}(
             stack.badDeliveryRequest, 1, source.relayProvider
         );
@@ -991,7 +986,7 @@ contract TestCoreRelayer is Test {
             TARGET_CHAIN_ID, uint256(gasParams.targetGasLimit - 1) * gasParams.targetGasPrice
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","27"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "27"));
         source.coreRelayer.requestDelivery{value: stack.payment}(stack.deliveryRequest, 1, source.relayProvider);
     }
 

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -560,7 +560,10 @@ contract TestCoreRelayer is Test {
         }
     }
 
-    function testRevertRedeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
+    function testRevertRedeliveryErrors(
+        GasParameters memory gasParams,
+        bytes memory message
+    ) public {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -627,7 +630,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)", 1));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         stack.originalDelivery.encodedVMs[1] = stack.originalDelivery.encodedVMs[0];
@@ -664,7 +667,7 @@ contract TestCoreRelayer is Test {
         });
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)", "VM signature invalid"));
+        vm.expectRevert(abi.encodeWithSignature("InvalidRedeliveryVM(string)","VM signature invalid"));
         target.coreRelayer.redeliverSingle{value: stack.budget}(stack.package);
 
         fakeVM = relayerWormholeSimulator.fetchSignedMessageFromLogs(
@@ -791,7 +794,9 @@ contract TestCoreRelayer is Test {
         ICoreRelayer.DeliveryInstruction instruction;
     }
 
-    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message) public {
+    function testRevertDeliveryErrors(GasParameters memory gasParams, bytes memory message)
+        public
+    {
         (uint16 SOURCE_CHAIN_ID, uint16 TARGET_CHAIN_ID, Contracts memory source, Contracts memory target) =
             standardAssumeAndSetupTwoChains(gasParams, 1000000);
 
@@ -885,7 +890,7 @@ contract TestCoreRelayer is Test {
             + target.wormhole.messageFee();
 
         vm.prank(target.relayer);
-        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)", 1));
+        vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint256)",1));
         target.coreRelayer.deliverSingle{value: stack.budget}(stack.package);
 
         stack.encodedVMs[1] = stack.encodedVMs[0];
@@ -958,7 +963,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "25"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","25"));
         source.coreRelayer.requestDelivery{value: stack.payment - 1}(stack.deliveryRequest, 1, source.relayProvider);
 
         source.relayProvider.updateDeliverGasOverhead(TARGET_CHAIN_ID, gasParams.evmGasOverhead);
@@ -975,7 +980,7 @@ contract TestCoreRelayer is Test {
             source.coreRelayer.getDefaultRelayParams()
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "26"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","26"));
         source.coreRelayer.requestDelivery{value: stack.deliveryOverhead - 1}(
             stack.badDeliveryRequest, 1, source.relayProvider
         );
@@ -986,7 +991,7 @@ contract TestCoreRelayer is Test {
             TARGET_CHAIN_ID, uint256(gasParams.targetGasLimit - 1) * gasParams.targetGasPrice
         );
 
-        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "27"));
+        vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)","27"));
         source.coreRelayer.requestDelivery{value: stack.payment}(stack.deliveryRequest, 1, source.relayProvider);
     }
 


### PR DESCRIPTION
This pull request adds NatSpec documentation coverage for the error types introduced in https://github.com/wormhole-foundation/trustless-generic-relayer/pull/37.

My understanding of these contracts is limited, so please please feel free to comment if you find any inaccuracies.

Some cases seemed to me more like internal errors (implementation details). Haven't decided what to do about them, maybe just adding a ```/// @notice Internal error``` is the right thing to do.