### PR TITLE
CI workflow: cache foundry release package

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,38 +44,36 @@ jobs:
     steps:
       - name: Checkout trustless-generic-relayer
         uses: actions/checkout@v3
-        with:
-          path: trustless-generic-relayer
       - name: Checkout wormhole
         uses: actions/checkout@v3
         with:
           repository: wormhole-foundation/wormhole
-          path: trustless-generic-relayer/ethereum/wormhole
+          path: ethereum/wormhole
           ref: feat/batch_vaa_alternative
       - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: "npm"
           cache-dependency-path: |
-            trustless-generic-relayer/ethereum/package-lock.json
-            trustless-generic-relayer/ethereum/wormhole/ethereum/package-lock.json
-            trustless-generic-relayer/relayer_engine/package-lock.json
-            trustless-generic-relayer/sdk/package-lock.json
+            ethereum/package-lock.json
+            ethereum/wormhole/ethereum/package-lock.json
+            relayer_engine/package-lock.json
+            sdk/package-lock.json
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Generate contract typechain typings
         run: |
-          cd trustless-generic-relayer/ethereum
+          cd ethereum
           make build
-      - run: cd trustless-generic-relayer/sdk && npm ci
+      - run: cd sdk && npm ci
       - name: Typecheck ethereum/ts-scripts
         run: |
-          cd trustless-generic-relayer/ethereum
+          cd ethereum
           npm ci
           npx tsc --noEmit --project ts-scripts
       - name: Typecheck relayer engine plugin
         run: |
-          cd trustless-generic-relayer/relayer_engine
+          cd relayer_engine
           npm ci
           npx tsc --noEmit --project tsconfig.json
 
@@ -84,32 +82,30 @@ jobs:
     steps:
       - name: Checkout trustless-generic-relayer
         uses: actions/checkout@v3
-        with:
-          path: trustless-generic-relayer
       - name: Checkout wormhole
         uses: actions/checkout@v3
         with:
           repository: wormhole-foundation/wormhole
-          path: trustless-generic-relayer/ethereum/wormhole
+          path: ethereum/wormhole
           ref: feat/batch_vaa_alternative
       - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: "npm"
           cache-dependency-path: |
-            trustless-generic-relayer/ethereum/package-lock.json
-            trustless-generic-relayer/ethereum/wormhole/ethereum/package-lock.json
-            trustless-generic-relayer/relayer_engine/package-lock.json
-            trustless-generic-relayer/sdk/package-lock.json
+            ethereum/package-lock.json
+            ethereum/wormhole/ethereum/package-lock.json
+            relayer_engine/package-lock.json
+            sdk/package-lock.json
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Generate contract typechain typings
         run: |
-          cd trustless-generic-relayer/ethereum
+          cd ethereum
           make build
-      - name: Typecheck relayer engine plugin
+      - name: Install relayer engine dependencies
         run: |
-          cd trustless-generic-relayer/relayer_engine
+          cd relayer_engine
           npm ci
 
       - name: Log in to the Container registry
@@ -128,7 +124,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          context: trustless-generic-relayer/relayer_engine
+          context: relayer_engine
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,20 +23,22 @@ jobs:
           cache-dependency-path: |
             ethereum/package-lock.json
             ethereum/wormhole/ethereum/package-lock.json
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - name: Run forge unit tests
         run: |
           cd ethereum
-          ../scripts/install-foundry
-          PATH=$PATH:$HOME/.foundry/bin/ make unit-test
+          make unit-test
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - name: Check that contracts are formatted
         run: |
           cd ethereum
-          ../scripts/install-foundry
-          PATH=$PATH:$HOME/.foundry/bin/ forge fmt --check
+          forge fmt --check
   typecheck:
     runs-on: ubuntu-latest
     steps:
@@ -59,11 +61,12 @@ jobs:
             trustless-generic-relayer/ethereum/wormhole/ethereum/package-lock.json
             trustless-generic-relayer/relayer_engine/package-lock.json
             trustless-generic-relayer/sdk/package-lock.json
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - name: Generate contract typechain typings
         run: |
           cd trustless-generic-relayer/ethereum
-          ../scripts/install-foundry
-          PATH=$PATH:$HOME/.foundry/bin/ make build
+          make build
       - run: cd trustless-generic-relayer/sdk && npm ci
       - name: Typecheck ethereum/ts-scripts
         run: |
@@ -98,11 +101,12 @@ jobs:
             trustless-generic-relayer/ethereum/wormhole/ethereum/package-lock.json
             trustless-generic-relayer/relayer_engine/package-lock.json
             trustless-generic-relayer/sdk/package-lock.json
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
       - name: Generate contract typechain typings
         run: |
           cd trustless-generic-relayer/ethereum
-          ../scripts/install-foundry
-          PATH=$PATH:$HOME/.foundry/bin/ make build
+          make build
       - name: Typecheck relayer engine plugin
         run: |
           cd trustless-generic-relayer/relayer_engine


### PR DESCRIPTION
This caches a particular release across action runners, lowering the chance of running into a 403 unauthorized access in GitHub.

It also simplifies some paths since the relayer engine is installed through npm.