### PR TITLE
Relay provider state docs

### DIFF
--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -60,7 +60,7 @@ contract RelayProvider is RelayProviderGovernance, IRelayProvider {
         return 200; //REVISE consider adding state variable for this
     }
 
-    //Returns a a buffer amount, and a buffer denominator, whereby the bufferAmount / bufferDenominator will be reduced from
+    //Returns a buffer amount, and a buffer denominator, whereby the bufferAmount / bufferDenominator will be reduced from
     //applicationBudget conversions, giving an overhead to the provider on each conversion
     function getAssetConversionBuffer(uint16 targetChain)
         public

--- a/ethereum/contracts/relayProvider/RelayProviderState.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderState.sol
@@ -5,24 +5,43 @@ pragma solidity ^0.8.0;
 
 contract RelayProviderStorage {
     struct PriceData {
+        // The price of purchasing 1 unit of gas on targetChain, denominated in targetChain's wei.
         uint128 gasPrice;
+        // The price of the native currency denominated in USD * 10^6
         uint128 nativeCurrencyPrice;
     }
 
     struct State {
+        // Wormhole chain id of this blockchain.
         uint16 chainId;
+        // Current owner.
         address owner;
+        // Pending target of ownership transfer.
         address pendingOwner;
+        // Address of the core relayer contract.
         address payable coreRelayer;
+        // Dictionary of implementation contract -> initialized flag
         mapping(address => bool) initializedImplementations;
+        // Dictionary of wormhole chain id -> price data
         mapping(uint16 => PriceData) data;
+        // The delivery overhead gas required to deliver a message to targetChain, denominated in targetChain's gas.
         mapping(uint16 => uint32) deliverGasOverhead;
+        // The wormhole fee to deliver a message to targetChain, denominated in targetChain's wei.
         mapping(uint16 => uint32) wormholeFee;
+        // The maximum budget that is allowed for a delivery on target chain, denominated in the targetChain's wei.
         mapping(uint16 => uint256) maximumBudget;
+        // Dictionary of wormhole chain id -> wormhole address for the relayer provider contract in target chain.
         mapping(uint16 => bytes32) deliveryAddressMap;
+        // Set of relayer addresses used to deliver or redeliver wormhole messages.
         mapping(address => bool) approvedSenders;
+        // The following two fields are a percentage buffer that is used to upcharge the user for the application budget.
+        // The cost of getting ‘targetAmount’ on ‘targetChain’ for the applicationBudget is
+        // (denominator + buffer) / (denominator) * (the converted amount in source chain currency using the ‘quoteAssetPrice’ values)
+        // Dictionary of wormhole chain id -> assetConversionBuffer buffer
         mapping(uint16 => uint16) assetConversionBuffer;
+        // Dictionary of wormhole chain id -> assetConversionBufferDenominator
         mapping(uint16 => uint16) assetConversionBufferDenominator;
+        // Reward address for the relayer. The CoreRelayer contract transfers the reward for relaying messages here.
         address rewardAddress;
     }
 }


### PR DESCRIPTION
I'm adding some comments to the `RelayProviderState` contract to make sure I'm not mistaken and having them for future reference.

In particular, I'm not sure if I'm missing something with the `assetConversionBuffer` and `assetConversionBufferDenominator`.
@chase-45 @derpy-duck I think you have context to know whether these are right or if something is missing. 