### PR TITLE
RelayProvider refactor state

### DIFF
--- a/ethereum/contracts/relayProvider/RelayProviderGetters.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGetters.sol
@@ -65,6 +65,7 @@ contract RelayProviderGetters is RelayProviderState {
         view
         returns (uint16 tolerance, uint16 toleranceDenominator)
     {
-        return (_state.assetConversionBuffer[targetChain], _state.assetConversionBufferDenominator[targetChain]);
+        RelayProviderStorage.AssetConversion storage assetConversion = _state.assetConversion[targetChain];
+        return (assetConversion.buffer, assetConversion.denominator);
     }
 }

--- a/ethereum/contracts/relayProvider/RelayProviderSetters.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetters.sol
@@ -58,7 +58,8 @@ contract RelayProviderSetters is Context, RelayProviderState {
     }
 
     function setAssetConversionBuffer(uint16 targetChain, uint16 tolerance, uint16 toleranceDenominator) internal {
-        _state.assetConversionBuffer[targetChain] = tolerance;
-        _state.assetConversionBufferDenominator[targetChain] = toleranceDenominator;
+        RelayProviderStorage.AssetConversion storage assetConversion = _state.assetConversion[targetChain];
+        assetConversion.buffer = tolerance;
+        assetConversion.denominator = toleranceDenominator;
     }
 }

--- a/ethereum/contracts/relayProvider/RelayProviderState.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderState.sol
@@ -11,6 +11,14 @@ contract RelayProviderStorage {
         uint128 nativeCurrencyPrice;
     }
 
+    struct AssetConversion {
+        // The following two fields are a percentage buffer that is used to upcharge the user for the value attached to the message sent.
+        // The cost of getting ‘targetAmount’ on ‘targetChain’ for the receiverValue is
+        // (denominator + buffer) / (denominator) * (the converted amount in source chain currency using the ‘quoteAssetPrice’ values)
+        uint16 buffer;
+        uint16 denominator;
+    }
+
     struct State {
         // Wormhole chain id of this blockchain.
         uint16 chainId;
@@ -34,13 +42,8 @@ contract RelayProviderStorage {
         mapping(uint16 => bytes32) deliveryAddressMap;
         // Set of relayer addresses used to deliver or redeliver wormhole messages.
         mapping(address => bool) approvedSenders;
-        // The following two fields are a percentage buffer that is used to upcharge the user for the application budget.
-        // The cost of getting ‘targetAmount’ on ‘targetChain’ for the receiverValue is
-        // (denominator + buffer) / (denominator) * (the converted amount in source chain currency using the ‘quoteAssetPrice’ values)
-        // Dictionary of wormhole chain id -> assetConversionBuffer buffer
-        mapping(uint16 => uint16) assetConversionBuffer;
-        // Dictionary of wormhole chain id -> assetConversionBufferDenominator
-        mapping(uint16 => uint16) assetConversionBufferDenominator;
+        // Dictionary of wormhole chain id -> assetConversion
+        mapping(uint16 => AssetConversion) assetConversion;
         // Reward address for the relayer. The CoreRelayer contract transfers the reward for relaying messages here.
         address rewardAddress;
     }


### PR DESCRIPTION
This declares a struct `AssetConversion` where the `buffer` and `denominator` values are stored and uses a single dictionary to store these per chain. This cuts reads or stores for the corresponding getter or setter by half per call.

Note that this alters the storage layout of the `RelayProvider` contract.