### PR TITLE
Removes `truffle compile` and npm clean install for wormhole dependency.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
           cache: "npm"
           cache-dependency-path: |
             ethereum/package-lock.json
-            ethereum/wormhole/ethereum/package-lock.json
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run forge unit tests
@@ -58,7 +57,6 @@ jobs:
           cache: "npm"
           cache-dependency-path: |
             ethereum/package-lock.json
-            ethereum/wormhole/ethereum/package-lock.json
             relayer_engine/package-lock.json
             sdk/package-lock.json
       - name: Install Foundry
@@ -95,7 +93,6 @@ jobs:
           cache: "npm"
           cache-dependency-path: |
             ethereum/package-lock.json
-            ethereum/wormhole/ethereum/package-lock.json
             relayer_engine/package-lock.json
             sdk/package-lock.json
       - name: Install Foundry

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -23,17 +23,10 @@ lib/forge-std:
 	forge install foundry-rs/forge-std@2c7cbfc6fbede6d7c9e6b17afe997e3fdfe22fef --no-git --no-commit
 
 .PHONY: wormhole_dependencies
-wormhole_dependencies: wormhole/ethereum/build
+wormhole_dependencies: wormhole
 
 wormhole:
 	git clone --depth 1 --branch feat/batch_vaa_alternative --single-branch https://github.com/wormhole-foundation/wormhole.git
-
-.PHONY: wormhole/ethereum/build
-wormhole/ethereum/build: wormhole wormhole/ethereum/node_modules
-	cd wormhole/ethereum && npm run build && make .env
-
-wormhole/ethereum/node_modules:
-	cd wormhole/ethereum && npm ci
 
 dependencies: node_modules forge_dependencies wormhole_dependencies
 


### PR DESCRIPTION
This speeds up the CI pipeline considerably.

I'm not sure if these are necessary for development. If that's the case, I could tweak the makefile a bit so the CI doesn't trigger them while still keeping them for development.