### PR TITLE
Optimizes storage read in `_executeDelivery`

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -209,8 +209,10 @@ contract CoreRelayer is CoreRelayerGovernance {
         );
     }
 
-    function emitForward(uint256 refundAmount) internal returns (uint64, bool) {
-        ForwardingRequest memory forwardingRequest = getForwardingRequest();
+    function emitForward(uint256 refundAmount, ForwardingRequest memory forwardingRequest)
+        internal
+        returns (uint64, bool)
+    {
         DeliveryRequestsContainer memory container =
             decodeDeliveryRequestsContainer(forwardingRequest.deliveryRequestsContainer);
 
@@ -446,7 +448,7 @@ contract CoreRelayer is CoreRelayerGovernance {
             forwardingRequest.isValid
                 && (forwardingRequest.sender == fromWormholeFormat(internalInstruction.targetAddress))
         ) {
-            (, success) = emitForward(weiToRefund);
+            (, success) = emitForward(weiToRefund, forwardingRequest);
             if (success) {
                 emit ForwardRequestSuccess(
                     deliveryVaaHash, fromWormholeFormat(internalInstruction.targetAddress), sourceChain, sourceSequence


### PR DESCRIPTION
Avoids double read on the same storage slot. With this, the forwarding request is read only once.

I'm currently wondering if the forwarding request read at [line 484](https://github.com/wormhole-foundation/trustless-generic-relayer/blob/bf33efd6bc3d8edb982b4bc8ca05b52d7ac219ef/ethereum/contracts/coreRelayer/CoreRelayer.sol#L484) is redundant too. The contract doesn't seem to do anything with such a request at this point. Is it handled elsewhere? As far as I can see, the forwarding request is left in the storage as is.