### PR TITLE
Adds `memory-safe` tag to assembly sections in `BytesLib`.

### DIFF
--- a/ethereum/contracts/libraries/external/BytesLib.sol
+++ b/ethereum/contracts/libraries/external/BytesLib.sol
@@ -12,7 +12,7 @@ library BytesLib {
     function concat(bytes memory _preBytes, bytes memory _postBytes) internal pure returns (bytes memory) {
         bytes memory tempBytes;
 
-        assembly {
+        assembly ("memory-safe") {
             // Get a location of some free memory and store it in tempBytes as
             // Solidity does for memory variables.
             tempBytes := mload(0x40)
@@ -80,7 +80,7 @@ library BytesLib {
     }
 
     function concatStorage(bytes storage _preBytes, bytes memory _postBytes) internal {
-        assembly {
+        assembly ("memory-safe") {
             // Read the first 32 bytes of _preBytes storage, which is the length
             // of the array. (We don't need to use the offset into the slot
             // because arrays use the entire slot.)
@@ -215,7 +215,7 @@ library BytesLib {
 
         bytes memory tempBytes;
 
-        assembly {
+        assembly ("memory-safe") {
             switch iszero(_length)
             case 0 {
                 // Get a location of some free memory and store it in tempBytes as
@@ -272,7 +272,7 @@ library BytesLib {
         require(_bytes.length >= _start + 20, "toAddress_outOfBounds");
         address tempAddress;
 
-        assembly {
+        assembly ("memory-safe") {
             tempAddress := div(mload(add(add(_bytes, 0x20), _start)), 0x1000000000000000000000000)
         }
 
@@ -283,7 +283,7 @@ library BytesLib {
         require(_bytes.length >= _start + 1, "toUint8_outOfBounds");
         uint8 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0x1), _start))
         }
 
@@ -294,7 +294,7 @@ library BytesLib {
         require(_bytes.length >= _start + 2, "toUint16_outOfBounds");
         uint16 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0x2), _start))
         }
 
@@ -305,7 +305,7 @@ library BytesLib {
         require(_bytes.length >= _start + 4, "toUint32_outOfBounds");
         uint32 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0x4), _start))
         }
 
@@ -316,7 +316,7 @@ library BytesLib {
         require(_bytes.length >= _start + 8, "toUint64_outOfBounds");
         uint64 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0x8), _start))
         }
 
@@ -327,7 +327,7 @@ library BytesLib {
         require(_bytes.length >= _start + 12, "toUint96_outOfBounds");
         uint96 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0xc), _start))
         }
 
@@ -338,7 +338,7 @@ library BytesLib {
         require(_bytes.length >= _start + 16, "toUint128_outOfBounds");
         uint128 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0x10), _start))
         }
 
@@ -349,7 +349,7 @@ library BytesLib {
         require(_bytes.length >= _start + 32, "toUint256_outOfBounds");
         uint256 tempUint;
 
-        assembly {
+        assembly ("memory-safe") {
             tempUint := mload(add(add(_bytes, 0x20), _start))
         }
 
@@ -360,7 +360,7 @@ library BytesLib {
         require(_bytes.length >= _start + 32, "toBytes32_outOfBounds");
         bytes32 tempBytes32;
 
-        assembly {
+        assembly ("memory-safe") {
             tempBytes32 := mload(add(add(_bytes, 0x20), _start))
         }
 
@@ -370,7 +370,7 @@ library BytesLib {
     function equal(bytes memory _preBytes, bytes memory _postBytes) internal pure returns (bool) {
         bool success = true;
 
-        assembly {
+        assembly ("memory-safe") {
             let length := mload(_preBytes)
 
             // if lengths don't match the arrays are not equal
@@ -412,7 +412,7 @@ library BytesLib {
     function equalStorage(bytes storage _preBytes, bytes memory _postBytes) internal view returns (bool) {
         bool success = true;
 
-        assembly {
+        assembly ("memory-safe") {
             // we know _preBytes_offset is 0
             let fslot := sload(_preBytes.slot)
             // Decode the length of the stored array like in concatStorage().


### PR DESCRIPTION
This improves codegen in the compiler and reduces the chance of untraceable internal codegen errors when dealing with stack variables that can't be referenced with an instruction.

I've been running into these codegen errors quite a bit while tweaking forge tests but this seems to eliminate them.

In other news, this shaves off 1KB from the contract bytecode so that's a good thing.

The bad news is that marking these sections as memory safe is unsafe to do if they don't actually respect Solidity's memory model. I was actually thinking of creating a reduced version of the `BytesLib` since we don't use all of it but I prefer to do that in another pull request.