### PR TITLE
Filter EVM logs in unit tests read by generic relayer to just wormhole publish message logs.

### DIFF
--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -1219,12 +1219,16 @@ contract TestCoreRelayer is Test {
     mapping(bytes32 => ICoreRelayer.TargetDeliveryParametersSingle) pastDeliveries;
 
     function genericRelayer(uint16 chainId, uint8 num) internal {
-        Vm.Log[] memory entries = vm.getRecordedLogs();
         bytes[] memory encodedVMs = new bytes[](num);
-        for (uint256 i = 0; i < num; i++) {
-            encodedVMs[i] = relayerWormholeSimulator.fetchSignedMessageFromLogs(
-                entries[i], chainId, address(uint160(uint256(bytes32(entries[i].topics[1]))))
-            );
+        {
+            // Filters all events to just the wormhole messages.
+            Vm.Log[] memory entries = relayerWormholeSimulator.fetchWormholeMessageFromLog(vm.getRecordedLogs());
+            assertTrue(entries.length >= num);
+            for (uint256 i = 0; i < num; i++) {
+                encodedVMs[i] = relayerWormholeSimulator.fetchSignedMessageFromLogs(
+                    entries[i], chainId, address(uint160(uint256(bytes32(entries[i].topics[1]))))
+                );
+            }
         }
 
         IWormhole.VM[] memory parsed = new IWormhole.VM[](encodedVMs.length);

--- a/ethereum/forge-test/WormholeSimulator.sol
+++ b/ethereum/forge-test/WormholeSimulator.sol
@@ -143,17 +143,19 @@ contract WormholeSimulator {
     /**
      * @notice Finds published Wormhole events in forge logs
      * @param logs The forge Vm.log captured when recording events during test execution
-     * @param numMessages The expected number of Wormhole events in the forge logs
      */
-    function fetchWormholeMessageFromLog(Vm.Log[] memory logs, uint8 numMessages)
-        public
-        pure
-        returns (Vm.Log[] memory)
-    {
-        // create log array to save published messages
-        Vm.Log[] memory published = new Vm.Log[](numMessages);
+    function fetchWormholeMessageFromLog(Vm.Log[] memory logs) public pure returns (Vm.Log[] memory) {
+        uint256 count = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == keccak256("LogMessagePublished(address,uint64,uint32,bytes,uint8)")) {
+                count += 1;
+            }
+        }
 
-        uint8 publishedIndex = 0;
+        // create log array to save published messages
+        Vm.Log[] memory published = new Vm.Log[](count);
+
+        uint256 publishedIndex = 0;
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == keccak256("LogMessagePublished(address,uint64,uint32,bytes,uint8)")) {
                 published[publishedIndex] = logs[i];


### PR DESCRIPTION
This avoids having a test fail due to the wrong type of event being read by the generic relayer simulator.

Note that this change depends on #81, otherwise the compiler errors out with an internal codegen error related to "unreachable" stack variables.