### PR TITLE
Negative test for a reentrant attack on the core relayer forward mechanism

### DIFF
--- a/ethereum/contracts/mock/AttackForwardIntegration.sol
+++ b/ethereum/contracts/mock/AttackForwardIntegration.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import "../interfaces/IWormhole.sol";
+import "../interfaces/IWormholeReceiver.sol";
+import "../interfaces/ICoreRelayer.sol";
+
+/**
+ * This contract is a malicious "integration" that attempts to attack the forward mechanism.
+ */
+contract AttackForwardIntegration is IWormholeReceiver {
+    mapping(bytes32 => bool) consumedMessages;
+    address attackerReward;
+    IWormhole wormhole;
+    ICoreRelayer core_relayer;
+    uint32 nonce = 1;
+    uint16 targetChainId;
+
+    // Capture 30k gas for fees
+    // This just needs to be enough to pay for the call to the destination address.
+    uint32 SAFE_DELIVERY_GAS_CAPTURE = 30000;
+
+    constructor(IWormhole initWormhole, ICoreRelayer initCoreRelayer, uint16 chainId, address initAttackerReward) {
+        attackerReward = initAttackerReward;
+        wormhole = initWormhole;
+        core_relayer = initCoreRelayer;
+        targetChainId = chainId;
+    }
+
+    // This is the function which receives all messages from the remote contracts.
+    function receiveWormholeMessages(bytes[] memory vaas, bytes[] memory additionalData) public payable override {
+        // Do nothing. The attacker doesn't care about this message; he sends it himself.
+    }
+
+    receive() external payable {
+        // Request forward from the relayer network
+        // The core relayer could in principle accept the request due to this being the target of the message at the same time as being the refund address.
+        // Note that, if succesful, this forward request would be processed after the time for processing forwards is past.
+        // Thus, the request would "linger" in the forward request cache and be attended to in the next delivery.
+        requestForward(targetChainId, toWormholeFormat(attackerReward));
+    }
+
+    function requestForward(uint16 targetChain, bytes32 attackerRewardAddress) internal {
+        uint256 computeBudget = core_relayer.quoteGasDeliveryFee(
+            targetChain, SAFE_DELIVERY_GAS_CAPTURE, core_relayer.getDefaultRelayProvider()
+        );
+
+        ICoreRelayer.DeliveryRequest memory request = ICoreRelayer.DeliveryRequest({
+            targetChain: targetChain,
+            targetAddress: attackerRewardAddress,
+            // All remaining funds will be returned to the attacker
+            refundAddress: attackerRewardAddress,
+            computeBudget: computeBudget,
+            applicationBudget: 0,
+            relayParameters: core_relayer.getDefaultRelayParams()
+        });
+
+        core_relayer.requestForward{value: computeBudget}(request, nonce, core_relayer.getDefaultRelayProvider());
+    }
+
+    function toWormholeFormat(address addr) public pure returns (bytes32 whFormat) {
+        return bytes32(uint256(uint160(addr)));
+    }
+}

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -515,7 +515,8 @@ contract TestCoreRelayer is Test {
         StandardSetupTwoChains memory setup = standardAssumeAndSetupTwoChains(gasParams, feeParams, 1000000);
 
         // Collected funds from the attack are meant to be sent here.
-        address attackerSourceAddress = address(uint160(uint256(keccak256(abi.encodePacked(bytes("attackerAddress"), setup.sourceChainId)))));
+        address attackerSourceAddress =
+            address(uint160(uint256(keccak256(abi.encodePacked(bytes("attackerAddress"), setup.sourceChainId)))));
         assertTrue(attackerSourceAddress.balance == 0);
 
         // Borrowed assumes from testForward. They should help since this test is similar.
@@ -534,15 +535,14 @@ contract TestCoreRelayer is Test {
                 < uint256(2) ** 222 / feeParams.targetNativePrice
         );
 
-
-
         // Estimate the cost based on the initialized values
         uint256 computeBudget = setup.source.coreRelayer.quoteGasDeliveryFee(
             setup.targetChainId, gasParams.targetGasLimit, setup.source.relayProvider
         );
 
         {
-            AttackForwardIntegration attackerContract = new AttackForwardIntegration(setup.target.wormhole, setup.target.coreRelayer, setup.targetChainId, attackerSourceAddress);
+            AttackForwardIntegration attackerContract =
+            new AttackForwardIntegration(setup.target.wormhole, setup.target.coreRelayer, setup.targetChainId, attackerSourceAddress);
             bytes memory attackMsg = "attack";
 
             vm.recordLogs();
@@ -559,7 +559,6 @@ contract TestCoreRelayer is Test {
             // The message delivery should fail
             assertTrue(keccak256(setup.target.integration.getMessage()) != keccak256(attackMsg));
         }
-
 
         {
             // Now one victim sends their message. It doesn't need to be from the same source chain.
@@ -584,7 +583,6 @@ contract TestCoreRelayer is Test {
             // Here we assert that the victim's refund is safe.
             assertTrue(victimBalancePreDelivery < setup.target.refundAddress.balance);
         }
-
 
         Vm.Log[] memory entries = relayerWormholeSimulator.fetchWormholeMessageFromLog(vm.getRecordedLogs());
         if (entries.length > 0) {


### PR DESCRIPTION
Depends on #82. I thought that the modification to the `genericRelayer()` function that simulates the relaying there was enough, but I still needed a way to conditionally invoke the mechanism without it failing and had to do further adjustments. In this way, the relayer can be simulated if the attack is successful, ensuring the test fails in that case.

To test that the test does fail when the attack is successful you can comment [these](https://github.com/wormhole-foundation/trustless-generic-relayer/blob/346e9311f6a1c5d2ff422396372b723a5b7f4bea/ethereum/contracts/coreRelayer/CoreRelayer.sol#L189-L191) and [this](https://github.com/wormhole-foundation/trustless-generic-relayer/blob/346e9311f6a1c5d2ff422396372b723a5b7f4bea/ethereum/contracts/coreRelayer/CoreRelayer.sol#L457) lines.