### PR TITLE
Better typechecking for contracts

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -449,13 +449,13 @@ contract CoreRelayer is CoreRelayerGovernance {
         if (forwardingRequest.isValid) {
             (, success) = emitForward(weiToRefund, forwardingRequest);
             if (success) {
-                emit Delivery(
-                    fromWormholeFormat(internalInstruction.targetAddress),
-                    sourceChain,
-                    sourceSequence,
-                    deliveryVaaHash,
-                    uint8(DeliveryStatus.FORWARD_REQUEST_SUCCESS)
-                    );
+                emit Delivery({
+                    recipientContract: fromWormholeFormat(internalInstruction.targetAddress),
+                    sourceChain: sourceChain,
+                    sequence: sourceSequence,
+                    deliveryVaaHash: deliveryVaaHash,
+                    status: uint8(DeliveryStatus.FORWARD_REQUEST_SUCCESS)
+                });
             } else {
                 (bool sent,) = fromWormholeFormat(internalInstruction.refundAddress).call{value: weiToRefund}("");
 
@@ -463,13 +463,13 @@ contract CoreRelayer is CoreRelayerGovernance {
                     // if refunding fails, pay out full refund to relayer
                     weiToRefund = 0;
                 }
-                emit Delivery(
-                    fromWormholeFormat(internalInstruction.targetAddress),
-                    sourceChain,
-                    sourceSequence,
-                    deliveryVaaHash,
-                    uint8(DeliveryStatus.FORWARD_REQUEST_FAILURE)
-                    );
+                emit Delivery({
+                    recipientContract: fromWormholeFormat(internalInstruction.targetAddress),
+                    sourceChain: sourceChain,
+                    sequence: sourceSequence,
+                    deliveryVaaHash: deliveryVaaHash,
+                    status: uint8(DeliveryStatus.FORWARD_REQUEST_FAILURE)
+                });
             }
         } else {
             (bool sent,) = fromWormholeFormat(internalInstruction.refundAddress).call{value: weiToRefund}("");
@@ -480,21 +480,21 @@ contract CoreRelayer is CoreRelayerGovernance {
             }
 
             if (success) {
-                emit Delivery(
-                    fromWormholeFormat(internalInstruction.targetAddress),
-                    sourceChain,
-                    sourceSequence,
-                    deliveryVaaHash,
-                    uint8(DeliveryStatus.SUCCESS)
-                    );
+                emit Delivery({
+                    recipientContract: fromWormholeFormat(internalInstruction.targetAddress),
+                    sourceChain: sourceChain,
+                    sequence: sourceSequence,
+                    deliveryVaaHash: deliveryVaaHash,
+                    status: uint8(DeliveryStatus.SUCCESS)
+                });
             } else {
-                emit Delivery(
-                    fromWormholeFormat(internalInstruction.targetAddress),
-                    sourceChain,
-                    sourceSequence,
-                    deliveryVaaHash,
-                    uint8(DeliveryStatus.RECEIVER_FAILURE)
-                    );
+                emit Delivery({
+                    recipientContract: fromWormholeFormat(internalInstruction.targetAddress),
+                    sourceChain: sourceChain,
+                    sequence: sourceSequence,
+                    deliveryVaaHash: deliveryVaaHash,
+                    status: uint8(DeliveryStatus.RECEIVER_FAILURE)
+                });
             }
         }
 
@@ -591,13 +591,13 @@ contract CoreRelayer is CoreRelayerGovernance {
         );
 
         if (!valid) {
-            emit Delivery(
-                fromWormholeFormat(instruction.targetAddress),
-                redeliveryVM.emitterChainId,
-                redeliveryVM.sequence,
-                redeliveryVM.hash,
-                uint8(DeliveryStatus.INVALID_REDELIVERY)
-                );
+            emit Delivery({
+                recipientContract: fromWormholeFormat(instruction.targetAddress),
+                sourceChain: redeliveryVM.emitterChainId,
+                sequence: redeliveryVM.sequence,
+                deliveryVaaHash: redeliveryVM.hash,
+                status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+            });
             targetParams.relayerRefundAddress.send(msg.value);
             return;
         }

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -25,7 +25,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         uint16 indexed sourceChain,
         uint64 indexed sequence,
         bytes32 deliveryVaaHash,
-        uint8 status
+        DeliveryStatus status
     );
 
     error InsufficientFunds(string reason);
@@ -454,7 +454,7 @@ contract CoreRelayer is CoreRelayerGovernance {
                     sourceChain: sourceChain,
                     sequence: sourceSequence,
                     deliveryVaaHash: deliveryVaaHash,
-                    status: uint8(DeliveryStatus.FORWARD_REQUEST_SUCCESS)
+                    status: DeliveryStatus.FORWARD_REQUEST_SUCCESS
                 });
             } else {
                 (bool sent,) = fromWormholeFormat(internalInstruction.refundAddress).call{value: weiToRefund}("");
@@ -468,7 +468,7 @@ contract CoreRelayer is CoreRelayerGovernance {
                     sourceChain: sourceChain,
                     sequence: sourceSequence,
                     deliveryVaaHash: deliveryVaaHash,
-                    status: uint8(DeliveryStatus.FORWARD_REQUEST_FAILURE)
+                    status: DeliveryStatus.FORWARD_REQUEST_FAILURE
                 });
             }
         } else {
@@ -485,7 +485,7 @@ contract CoreRelayer is CoreRelayerGovernance {
                     sourceChain: sourceChain,
                     sequence: sourceSequence,
                     deliveryVaaHash: deliveryVaaHash,
-                    status: uint8(DeliveryStatus.SUCCESS)
+                    status: DeliveryStatus.SUCCESS
                 });
             } else {
                 emit Delivery({
@@ -493,7 +493,7 @@ contract CoreRelayer is CoreRelayerGovernance {
                     sourceChain: sourceChain,
                     sequence: sourceSequence,
                     deliveryVaaHash: deliveryVaaHash,
-                    status: uint8(DeliveryStatus.RECEIVER_FAILURE)
+                    status: DeliveryStatus.RECEIVER_FAILURE
                 });
             }
         }
@@ -596,7 +596,7 @@ contract CoreRelayer is CoreRelayerGovernance {
                 sourceChain: redeliveryVM.emitterChainId,
                 sequence: redeliveryVM.sequence,
                 deliveryVaaHash: redeliveryVM.hash,
-                status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+                status: DeliveryStatus.INVALID_REDELIVERY
             });
             targetParams.relayerRefundAddress.send(msg.value);
             return;

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.0;
 
 import "../libraries/external/BytesLib.sol";
+import "../interfaces/IWormholeReceiver.sol";
 
 import "./CoreRelayerGovernance.sol";
 import "./CoreRelayerStructs.sol";
@@ -409,7 +410,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         (bool success,) = fromWormholeFormat(internalInstruction.targetAddress).call{
             gas: internalInstruction.executionParameters.gasLimit,
             value: internalInstruction.receiverValueTarget
-        }(abi.encodeWithSignature("receiveWormholeMessages(bytes[],bytes[])", encodedVMs, new bytes[](0)));
+        }(abi.encodeCall(IWormholeReceiver.receiveWormholeMessages, (encodedVMs, new bytes[](0))));
 
         uint256 postGas = gasleft();
         // There's no easy way to measure the exact cost of the CALL instruction.

--- a/ethereum/contracts/example_integrations/xMint/Hub.sol
+++ b/ethereum/contracts/example_integrations/xMint/Hub.sol
@@ -80,14 +80,7 @@ contract XmintHub is ERC20, IWormholeReceiver {
             //token, amount, receipientChain, recipientAddress, nonce, payload
             abi.encodeCall(
                 ITokenBridge.transferTokensWithPayload,
-                (
-                    address(this),
-                    amount,
-                    remoteChain,
-                    trustedContracts[remoteChain],
-                    nonce,
-                    payload
-                )
+                (address(this), amount, remoteChain, trustedContracts[remoteChain], nonce, payload)
             )
         );
     }

--- a/ethereum/contracts/example_integrations/xMint/Hub.sol
+++ b/ethereum/contracts/example_integrations/xMint/Hub.sol
@@ -78,14 +78,16 @@ contract XmintHub is ERC20, IWormholeReceiver {
     function bridgeTokens(uint16 remoteChain, bytes memory payload, uint256 amount) internal {
         (bool success, bytes memory data) = address(token_bridge).call{value: amount + core_bridge.messageFee()}(
             //token, amount, receipientChain, recipientAddress, nonce, payload
-            abi.encodeWithSignature(
-                "transferTokensWithPayload(address,uint256,uint16,bytes32,nonce,bytes memory)",
-                address(this),
-                amount,
-                remoteChain,
-                trustedContracts[remoteChain],
-                nonce,
-                payload
+            abi.encodeCall(
+                ITokenBridge.transferTokensWithPayload,
+                (
+                    address(this),
+                    amount,
+                    remoteChain,
+                    trustedContracts[remoteChain],
+                    nonce,
+                    payload
+                )
             )
         );
     }

--- a/ethereum/contracts/example_integrations/xMint/Spoke.sol
+++ b/ethereum/contracts/example_integrations/xMint/Spoke.sol
@@ -55,12 +55,14 @@ contract XmintSpoke is IWormholeReceiver {
         uint256 bridgeAmount = msg.value - deliveryFeeBuffer - core_bridge.messageFee();
 
         (bool success, bytes memory data) = address(token_bridge).call{value: bridgeAmount + core_bridge.messageFee()}(
-            abi.encodeWithSignature(
-                "wrapAndTransferETHWithPayload(unit16,bytes32,uint32,bytes)",
-                hub_contract_chain,
-                hub_contract_address,
-                nonce,
-                abi.encode(core_relayer.toWormholeFormat(msg.sender))
+            abi.encodeCall(
+                ITokenBridge.wrapAndTransferETHWithPayload,
+                (
+                    hub_contract_chain,
+                    hub_contract_address,
+                    nonce,
+                    abi.encode(core_relayer.toWormholeFormat(msg.sender))
+                )
             )
         );
 

--- a/ethereum/contracts/example_integrations/xMint/Spoke.sol
+++ b/ethereum/contracts/example_integrations/xMint/Spoke.sol
@@ -57,12 +57,7 @@ contract XmintSpoke is IWormholeReceiver {
         (bool success, bytes memory data) = address(token_bridge).call{value: bridgeAmount + core_bridge.messageFee()}(
             abi.encodeCall(
                 ITokenBridge.wrapAndTransferETHWithPayload,
-                (
-                    hub_contract_chain,
-                    hub_contract_address,
-                    nonce,
-                    abi.encode(core_relayer.toWormholeFormat(msg.sender))
-                )
+                (hub_contract_chain, hub_contract_address, nonce, abi.encode(core_relayer.toWormholeFormat(msg.sender)))
             )
         );
 

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -1142,8 +1142,12 @@ contract TestCoreRelayer is Test {
             stack.encodedVMs[1] = stack.actualVM2;
             stack.encodedVMs[2] = stack.deliveryVM;
 
-            stack.package =
-                CoreRelayerStructs.TargetDeliveryParametersSingle(stack.encodedVMs, 2, 0, payable(setup.target.relayer));
+            stack.package = CoreRelayerStructs.TargetDeliveryParametersSingle({
+                encodedVMs: stack.encodedVMs,
+                deliveryIndex: 2,
+                multisendIndex: 0,
+                relayerRefundAddress: payable(setup.target.relayer)
+            });
 
             stack.parsed = relayerWormhole.parseVM(stack.deliveryVM);
             stack.instruction =
@@ -1172,14 +1176,14 @@ contract TestCoreRelayer is Test {
             1, abi.encodePacked(uint8(0)), 200
         );
 
-        IWormholeRelayer.Send memory deliveryRequest = IWormholeRelayer.Send(
-            setup.targetChainId, //target chain
-            setup.source.coreRelayer.toWormholeFormat(address(setup.target.integration)),
-            setup.source.coreRelayer.toWormholeFormat(address(setup.target.refundAddress)),
-            stack.payment - setup.source.wormhole.messageFee(),
-            0,
-            setup.source.coreRelayer.getDefaultRelayParams()
-        );
+        IWormholeRelayer.Send memory deliveryRequest = IWormholeRelayer.Send({
+            targetChain: setup.targetChainId,
+            targetAddress: setup.source.coreRelayer.toWormholeFormat(address(setup.target.integration)),
+            refundAddress: setup.source.coreRelayer.toWormholeFormat(address(setup.target.refundAddress)),
+            maxTransactionFee: stack.payment - setup.source.wormhole.messageFee(),
+            receiverValue: 0,
+            relayParameters: setup.source.coreRelayer.getDefaultRelayParams()
+        });
 
         setup.source.coreRelayer.send{value: stack.payment}(deliveryRequest, 1, address(setup.source.relayProvider));
 
@@ -1206,8 +1210,12 @@ contract TestCoreRelayer is Test {
         stack.encodedVMs[1] = stack.actualVM2;
         stack.encodedVMs[2] = fakeVM;
 
-        stack.package =
-            CoreRelayerStructs.TargetDeliveryParametersSingle(stack.encodedVMs, 2, 0, payable(setup.target.relayer));
+        stack.package = CoreRelayerStructs.TargetDeliveryParametersSingle({
+            encodedVMs: stack.encodedVMs,
+            deliveryIndex: 2,
+            multisendIndex: 0,
+            relayerRefundAddress: payable(setup.target.relayer)
+        });
 
         stack.parsed = relayerWormhole.parseVM(stack.deliveryVM);
         stack.instruction =
@@ -1222,8 +1230,12 @@ contract TestCoreRelayer is Test {
 
         stack.encodedVMs[2] = stack.encodedVMs[0];
 
-        stack.package =
-            CoreRelayerStructs.TargetDeliveryParametersSingle(stack.encodedVMs, 2, 0, payable(setup.target.relayer));
+        stack.package = CoreRelayerStructs.TargetDeliveryParametersSingle({
+            encodedVMs: stack.encodedVMs,
+            deliveryIndex: 2,
+            multisendIndex: 0,
+            relayerRefundAddress: payable(setup.target.relayer)
+        });
 
         vm.prank(setup.target.relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidEmitter()"));
@@ -1231,8 +1243,12 @@ contract TestCoreRelayer is Test {
 
         stack.encodedVMs[2] = stack.deliveryVM;
 
-        stack.package =
-            CoreRelayerStructs.TargetDeliveryParametersSingle(stack.encodedVMs, 2, 0, payable(setup.target.relayer));
+        stack.package = CoreRelayerStructs.TargetDeliveryParametersSingle({
+            encodedVMs: stack.encodedVMs,
+            deliveryIndex: 2,
+            multisendIndex: 0,
+            relayerRefundAddress: payable(setup.target.relayer)
+        });
 
         vm.expectRevert(abi.encodeWithSignature("UnexpectedRelayer()"));
         setup.target.coreRelayerFull.deliverSingle{value: stack.budget}(stack.package);
@@ -1281,14 +1297,14 @@ contract TestCoreRelayer is Test {
             1, abi.encodePacked(uint8(0), bytes("hi!")), 200
         );
 
-        stack.deliveryRequest = IWormholeRelayer.Send(
-            setup.targetChainId, //target chain
-            setup.source.coreRelayer.toWormholeFormat(address(setup.target.integration)),
-            setup.source.coreRelayer.toWormholeFormat(address(setup.target.refundAddress)),
-            stack.payment - setup.source.wormhole.messageFee(),
-            0,
-            setup.source.coreRelayer.getDefaultRelayParams()
-        );
+        stack.deliveryRequest = IWormholeRelayer.Send({
+            targetChain: setup.targetChainId,
+            targetAddress: setup.source.coreRelayer.toWormholeFormat(address(setup.target.integration)),
+            refundAddress: setup.source.coreRelayer.toWormholeFormat(address(setup.target.refundAddress)),
+            maxTransactionFee: stack.payment - setup.source.wormhole.messageFee(),
+            receiverValue: 0,
+            relayParameters: setup.source.coreRelayer.getDefaultRelayParams()
+        });
 
         vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "25"));
         setup.source.coreRelayer.send{value: stack.payment - 1}(
@@ -1300,14 +1316,14 @@ contract TestCoreRelayer is Test {
         stack.deliveryOverhead = setup.source.relayProvider.quoteDeliveryOverhead(setup.targetChainId);
         vm.assume(stack.deliveryOverhead > 0);
 
-        stack.badSend = IWormholeRelayer.Send(
-            setup.targetChainId, //target chain
-            setup.source.coreRelayer.toWormholeFormat(address(setup.target.integration)),
-            setup.source.coreRelayer.toWormholeFormat(address(setup.target.refundAddress)),
-            stack.deliveryOverhead - 1,
-            0,
-            setup.source.coreRelayer.getDefaultRelayParams()
-        );
+        stack.badSend = IWormholeRelayer.Send({
+            targetChain: setup.targetChainId,
+            targetAddress: setup.source.coreRelayer.toWormholeFormat(address(setup.target.integration)),
+            refundAddress: setup.source.coreRelayer.toWormholeFormat(address(setup.target.refundAddress)),
+            maxTransactionFee: stack.deliveryOverhead - 1,
+            receiverValue: 0,
+            relayParameters: setup.source.coreRelayer.getDefaultRelayParams()
+        });
 
         vm.expectRevert(abi.encodeWithSignature("InsufficientFunds(string)", "26"));
         setup.source.coreRelayer.send{value: stack.deliveryOverhead - 1}(

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -828,7 +828,7 @@ contract TestCoreRelayer is Test {
         uint16 indexed sourceChain,
         uint64 indexed sequence,
         bytes32 deliveryVaaHash,
-        uint8 status
+        DeliveryStatus status
     );
 
     enum DeliveryStatus {
@@ -990,7 +990,7 @@ contract TestCoreRelayer is Test {
             sourceChain: setup.sourceChainId,
             sequence: 1,
             deliveryVaaHash: redeliveryVmHash,
-            status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+            status: DeliveryStatus.INVALID_REDELIVERY
         });
         setup.target.coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
 
@@ -1005,7 +1005,7 @@ contract TestCoreRelayer is Test {
             sourceChain: setup.sourceChainId,
             sequence: 1,
             deliveryVaaHash: redeliveryVmHash,
-            status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+            status: DeliveryStatus.INVALID_REDELIVERY
         });
         vm.prank(setup.target.relayer);
         map[differentChainId].coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
@@ -1054,7 +1054,7 @@ contract TestCoreRelayer is Test {
             sourceChain: setup.sourceChainId,
             sequence: 3,
             deliveryVaaHash: redeliveryVmHash,
-            status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+            status: DeliveryStatus.INVALID_REDELIVERY
         });
         vm.prank(setup.target.relayer);
         map[differentChainId].coreRelayerFull.redeliverSingle{

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -132,10 +132,12 @@ contract TestCoreRelayer is Test {
         RelayProviderImplementation relayProviderImplementation = new RelayProviderImplementation();
         RelayProviderProxy myRelayProvider = new RelayProviderProxy(
             address(relayProviderSetup),
-            abi.encodeWithSelector(
-                bytes4(keccak256("setup(address,uint16)")),
-                address(relayProviderImplementation),
-                chainId
+            abi.encodeCall(
+                RelayProviderSetup.setup,
+                (
+                    address(relayProviderImplementation),
+                    chainId
+                )
             )
         );
 
@@ -150,15 +152,17 @@ contract TestCoreRelayer is Test {
         CoreRelayerImplementation coreRelayerImplementation = new CoreRelayerImplementation();
         CoreRelayerProxy myCoreRelayer = new CoreRelayerProxy(
             address(coreRelayerSetup),
-            abi.encodeWithSelector(
-                bytes4(keccak256("setup(address,uint16,address,address,uint16,bytes32,uint256)")),
-                address(coreRelayerImplementation),
-                chainId,
-                wormhole,
-                defaultRelayProvider,
-                uint16(1), // governance chain id
-                0x0000000000000000000000000000000000000000000000000000000000000004, // governance contract
-                block.chainid
+            abi.encodeCall(
+                CoreRelayerSetup.setup,
+                (
+                    address(coreRelayerImplementation),
+                    chainId,
+                    wormhole,
+                    defaultRelayProvider,
+                    uint16(1), // governance chain id
+                    0x0000000000000000000000000000000000000000000000000000000000000004, // governance contract
+                    block.chainid
+                )
             )
         );
         coreRelayer = IWormholeRelayer(address(myCoreRelayer));

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -985,13 +985,13 @@ contract TestCoreRelayer is Test {
 
         bytes32 redeliveryVmHash = relayerWormhole.parseVM(stack.redeliveryVM).hash;
         vm.expectEmit(true, true, true, true, address(setup.target.coreRelayer));
-        emit Delivery(
-            address(setup.target.integration),
-            setup.sourceChainId,
-            1,
-            redeliveryVmHash,
-            uint8(DeliveryStatus.INVALID_REDELIVERY)
-            );
+        emit Delivery({
+            recipientContract: address(setup.target.integration),
+            sourceChain: setup.sourceChainId,
+            sequence: 1,
+            deliveryVaaHash: redeliveryVmHash,
+            status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+        });
         setup.target.coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
 
         uint16 differentChainId = 2;
@@ -1000,13 +1000,13 @@ contract TestCoreRelayer is Test {
         }
         vm.deal(setup.target.relayer, type(uint256).max);
         vm.expectEmit(true, true, true, true, address(map[differentChainId].coreRelayer));
-        emit Delivery(
-            address(setup.target.integration),
-            setup.sourceChainId,
-            1,
-            redeliveryVmHash,
-            uint8(DeliveryStatus.INVALID_REDELIVERY)
-            );
+        emit Delivery({
+            recipientContract: address(setup.target.integration),
+            sourceChain: setup.sourceChainId,
+            sequence: 1,
+            deliveryVaaHash: redeliveryVmHash,
+            status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+        });
         vm.prank(setup.target.relayer);
         map[differentChainId].coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
 
@@ -1049,13 +1049,13 @@ contract TestCoreRelayer is Test {
         vm.deal(setup.target.relayer, type(uint256).max);
 
         vm.expectEmit(true, true, true, true, address(map[differentChainId].coreRelayer));
-        emit Delivery(
-            address(setup.target.integration),
-            setup.sourceChainId,
-            3,
-            redeliveryVmHash,
-            uint8(DeliveryStatus.INVALID_REDELIVERY)
-            );
+        emit Delivery({
+            recipientContract: address(setup.target.integration),
+            sourceChain: setup.sourceChainId,
+            sequence: 3,
+            deliveryVaaHash: redeliveryVmHash,
+            status: uint8(DeliveryStatus.INVALID_REDELIVERY)
+        });
         vm.prank(setup.target.relayer);
         map[differentChainId].coreRelayerFull.redeliverSingle{
             value: stack.payment + map[differentChainId].wormhole.messageFee()

--- a/ethereum/forge-test/RelayProvider.t.sol
+++ b/ethereum/forge-test/RelayProvider.t.sol
@@ -22,10 +22,12 @@ contract TestRelayProvider is Test {
         RelayProviderImplementation relayProviderImplementation = new RelayProviderImplementation();
         RelayProviderProxy myRelayProvider = new RelayProviderProxy(
             address(relayProviderSetup),
-            abi.encodeWithSelector(
-                bytes4(keccak256("setup(address,uint16)")),
-                address(relayProviderImplementation),
-                TEST_ORACLE_CHAIN_ID
+            abi.encodeCall(
+                RelayProviderSetup.setup,
+                (
+                    address(relayProviderImplementation),
+                    TEST_ORACLE_CHAIN_ID
+                )
             )
         );
 


### PR DESCRIPTION
Replaces some `abi.encodeWithSignature` or `abi.encodeWithSelector` expressions with `abi.encodeCall` that the compiler typechecks.

Also adds use of named parameters in some more struct creation expressions.