### PR TITLE
Fixes relayer reward to take into account forward publish fee.

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -498,7 +498,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         }
 
         uint256 receiverValuePaid = (success ? internalInstruction.receiverValueTarget : 0);
-        uint256 wormholeFeePaid = getForwardingRequest().isValid ? wormhole.messageFee() : 0;
+        uint256 wormholeFeePaid = forwardingRequest.isValid ? wormhole.messageFee() : 0;
         uint256 relayerRefundAmount = msg.value - weiToRefund - receiverValuePaid - wormholeFeePaid;
         // refund the rest to relayer
         relayerRefund.call{value: relayerRefundAmount}("");


### PR DESCRIPTION
Edit: forgot to add an explanation here.

The `emitForward()` function always clears the forwarding request in the storage cache so the reward calculation never takes into account the cost of the wormhole message publish when a forward is processed.