### PR TITLE
Gas use and size improvements

### DIFF
--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -942,14 +942,13 @@ contract CoreRelayer is CoreRelayerGovernance {
         view
         returns (bytes memory newEncoded)
     {
-        newEncoded = abi.encodePacked(encoded, request.targetChain, request.targetAddress, request.refundAddress);
         newEncoded = abi.encodePacked(
-            newEncoded,
+            encoded,
+            request.targetChain,
+            request.targetAddress,
+            request.refundAddress,
             calculateTargetDeliveryMaximumRefund(request.targetChain, request.maxTransactionFee, provider),
-            convertApplicationBudgetAmount(request.receiverValue, request.targetChain, provider)
-        );
-        newEncoded = abi.encodePacked(
-            newEncoded,
+            convertApplicationBudgetAmount(request.receiverValue, request.targetChain, provider),
             uint8(1), //version for ExecutionParameters
             calculateTargetGasDeliveryAmount(request.targetChain, request.maxTransactionFee, provider),
             provider.getDeliveryAddress(request.targetChain)

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -271,6 +271,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         IRelayProvider selectedProvider = IRelayProvider(container.relayProviderAddress);
 
         for (uint16 i = 0; i < container.requests.length; i++) {
+            // TODO: Optimization opportunity here by reducing multiple calls to only one with all requested addresses.
             if (selectedProvider.getDeliveryAddress(container.requests[i].targetChain) == 0) {
                 revert RelayProviderDoesNotSupportTargetChain();
             }
@@ -926,7 +927,8 @@ contract CoreRelayer is CoreRelayerGovernance {
             uint8(container.requests.length) //number of requests in the array
         );
 
-        //Append all the messages to the array.
+        // TODO: this probably results in a quadratic algorithm. Further optimization can be done here.
+        // Append all the messages to the array.
         for (uint256 i = 0; i < container.requests.length; i++) {
             encoded = appendDeliveryInstruction(
                 encoded, container.requests[i], IRelayProvider(container.relayProviderAddress)

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -101,8 +101,16 @@ contract CoreRelayer is CoreRelayerGovernance {
             revert MsgValueTooLow();
         }
 
-        sequence =
-            emitRedelivery(request, nonce, provider.getConsistencyLevel(), receiverValueTarget, maximumRefund, provider, wormhole, wormholeMessageFee);
+        sequence = emitRedelivery(
+            request,
+            nonce,
+            provider.getConsistencyLevel(),
+            receiverValueTarget,
+            maximumRefund,
+            provider,
+            wormhole,
+            wormholeMessageFee
+        );
 
         //Send the delivery fees to the specified address of the provider.
         pay(provider.getRewardAddress(), msg.value - wormholeMessageFee);
@@ -166,8 +174,7 @@ contract CoreRelayer is CoreRelayerGovernance {
         IRelayProvider provider = IRelayProvider(deliveryRequests.relayProviderAddress);
         uint256 wormholeMessageFee = wormhole.messageFee();
 
-        sequence =
-            wormhole.publishMessage{value: wormholeMessageFee}(nonce, container, provider.getConsistencyLevel());
+        sequence = wormhole.publishMessage{value: wormholeMessageFee}(nonce, container, provider.getConsistencyLevel());
 
         //pay fee to provider
         pay(provider.getRewardAddress(), totalCost - wormholeMessageFee);

--- a/ethereum/contracts/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/coreRelayer/CoreRelayer.sol
@@ -906,10 +906,7 @@ contract CoreRelayer is CoreRelayerGovernance {
             uint32(request.sourceNonce),
             uint16(request.targetChain),
             uint8(request.deliveryIndex),
-            uint8(request.multisendIndex)
-        );
-        encoded = abi.encodePacked(
-            encoded,
+            uint8(request.multisendIndex),
             maximumRefund,
             receiverValueTarget,
             uint8(1), //version for ExecutionParameters

--- a/ethereum/contracts/interfaces/IRelayProvider.sol
+++ b/ethereum/contracts/interfaces/IRelayProvider.sol
@@ -26,7 +26,7 @@ interface IRelayProvider {
     //Otherwise, the delivery on the target chain (msg.sender) must equal this address.
     function getDeliveryAddress(uint16 targetChain) external view returns (bytes32 whAddress);
 
-    function getRewardAddress() external view returns (address rewardAddress);
+    function getRewardAddress() external view returns (address payable rewardAddress);
 
     function getConsistencyLevel() external view returns (uint8 consistencyLevel);
 }

--- a/ethereum/contracts/relayProvider/RelayProvider.sol
+++ b/ethereum/contracts/relayProvider/RelayProvider.sol
@@ -52,7 +52,7 @@ contract RelayProvider is RelayProviderGovernance, IRelayProvider {
     }
 
     //Returns the address on this chain that rewards should be sent to
-    function getRewardAddress() public view override returns (address) {
+    function getRewardAddress() public view override returns (address payable) {
         return rewardAddress();
     }
 

--- a/ethereum/contracts/relayProvider/RelayProviderGetters.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGetters.sol
@@ -52,7 +52,7 @@ contract RelayProviderGetters is RelayProviderState {
         return _state.wormholeFee[targetChainId];
     }
 
-    function rewardAddress() public view returns (address) {
+    function rewardAddress() public view returns (address payable) {
         return _state.rewardAddress;
     }
 

--- a/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderGovernance.sol
@@ -40,7 +40,7 @@ abstract contract RelayProviderGovernance is RelayProviderGetters, RelayProvider
         emit ApprovedSenderUpdated(sender, approved);
     }
 
-    function updateRewardAddress(address newAddress) public onlyOwner {
+    function updateRewardAddress(address payable newAddress) public onlyOwner {
         setRewardAddress(newAddress);
         emit RewardAddressUpdated(newAddress);
     }

--- a/ethereum/contracts/relayProvider/RelayProviderSetters.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderSetters.sol
@@ -40,7 +40,7 @@ contract RelayProviderSetters is Context, RelayProviderState {
         _state.wormholeFee[chainId] = wormholeFee;
     }
 
-    function setRewardAddress(address rewardAddress) internal {
+    function setRewardAddress(address payable rewardAddress) internal {
         _state.rewardAddress = rewardAddress;
     }
 

--- a/ethereum/contracts/relayProvider/RelayProviderState.sol
+++ b/ethereum/contracts/relayProvider/RelayProviderState.sol
@@ -42,7 +42,7 @@ contract RelayProviderStorage {
         // Dictionary of wormhole chain id -> assetConversionBufferDenominator
         mapping(uint16 => uint16) assetConversionBufferDenominator;
         // Reward address for the relayer. The CoreRelayer contract transfers the reward for relaying messages here.
-        address rewardAddress;
+        address payable rewardAddress;
     }
 }
 

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -567,6 +567,7 @@ contract TestCoreRelayer is Test {
 
         uint256 oldBalance = address(setup.target.integration).balance;
 
+        vm.deal(address(this), paymentNotEnough);
         setup.source.integration.sendMessageWithRefundAddress{value: paymentNotEnough}(
             message, setup.targetChainId, address(setup.target.integration), address(setup.target.refundAddress)
         );
@@ -596,7 +597,7 @@ contract TestCoreRelayer is Test {
             newRelayParameters: setup.source.coreRelayer.getDefaultRelayParams()
         });
 
-        vm.deal(address(this), type(uint256).max >> 2);
+        vm.deal(address(this), payment + newMaxTransactionFeeFee);
 
         setup.source.coreRelayer.resend{value: payment + newMaxTransactionFeeFee}(
             redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -655,7 +656,7 @@ contract TestCoreRelayer is Test {
             newRelayParameters: setup.source.coreRelayer.getDefaultRelayParams()
         });
 
-        vm.deal(address(this), type(uint256).max >> 2);
+        vm.deal(address(this), payment + newMaxTransactionFeeFee);
 
         setup.source.coreRelayer.resend{value: payment + newMaxTransactionFeeFee}(
             redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -707,6 +708,9 @@ contract TestCoreRelayer is Test {
             setup.targetChainId, gasParams.targetGasLimit, address(setup.source.relayProvider)
         ) + uint256(3) * setup.source.wormhole.messageFee();
 
+        // This avoids payment overflow in the target.
+        vm.assume(payment <= type(uint256).max >> 1);
+
         // start listening to events
         vm.recordLogs();
 
@@ -720,7 +724,7 @@ contract TestCoreRelayer is Test {
 
         vm.getRecordedLogs();
 
-        vm.deal(address(this), type(uint256).max >> 2);
+        vm.deal(address(this), payment);
 
         setup.source.integration.sendMessageWithRefundAddress{value: payment}(
             secondMessage, setup.targetChainId, address(setup.target.integration), address(setup.target.refundAddress)
@@ -844,7 +848,7 @@ contract TestCoreRelayer is Test {
             newReceiverValue: 0,
             newRelayParameters: setup.source.coreRelayer.getDefaultRelayParams()
         });
-        vm.deal(address(this), type(uint256).max >> 2);
+        vm.deal(address(this), stack.payment);
         vm.expectRevert(abi.encodeWithSignature("MsgValueTooLow()"));
         setup.source.coreRelayer.resend{value: stack.payment - 1}(
             stack.redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -877,7 +881,7 @@ contract TestCoreRelayer is Test {
         stack.budget = stack.instruction.newMaximumRefundTarget + stack.instruction.newReceiverValueTarget
             + setup.target.wormhole.messageFee();
 
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
+        vm.deal(setup.target.relayer, stack.budget);
 
         vm.prank(setup.target.relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint8)", 2));
@@ -923,7 +927,7 @@ contract TestCoreRelayer is Test {
         setup.target.coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
 
         setup.source.relayProvider.updateDeliveryAddress(setup.targetChainId, bytes32(uint256(uint160(address(this)))));
-        vm.deal(address(this), type(uint256).max >> 2);
+        vm.deal(address(this), stack.payment);
         vm.getRecordedLogs();
         setup.source.coreRelayer.resend{value: stack.payment}(
             stack.redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -948,6 +952,7 @@ contract TestCoreRelayer is Test {
             stack.redeliveryVM, stack.originalDelivery.encodedVMs, payable(msg.sender)
         );
 
+        vm.deal(address(this), stack.budget);
         bytes32 redeliveryVmHash = relayerWormhole.parseVM(stack.redeliveryVM).hash;
         vm.expectEmit(true, true, true, true, address(setup.target.coreRelayer));
         emit Delivery({
@@ -963,7 +968,7 @@ contract TestCoreRelayer is Test {
         if (setup.targetChainId == 2) {
             differentChainId = 3;
         }
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
+        vm.deal(setup.target.relayer, stack.budget);
         vm.expectEmit(true, true, true, true, address(map[differentChainId].coreRelayer));
         emit Delivery({
             recipientContract: address(setup.target.integration),
@@ -974,8 +979,6 @@ contract TestCoreRelayer is Test {
         });
         vm.prank(setup.target.relayer);
         map[differentChainId].coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
-
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
 
         stack.redeliveryRequest = IWormholeRelayer.ResendByTx({
             sourceChain: setup.sourceChainId,
@@ -993,7 +996,7 @@ contract TestCoreRelayer is Test {
         setup.source.relayProvider.updateDeliveryAddress(
             differentChainId, bytes32(uint256(uint160(address(setup.target.relayer))))
         );
-        vm.deal(address(this), type(uint256).max >> 2);
+        vm.deal(address(this), stack.payment);
         vm.getRecordedLogs();
         setup.source.coreRelayer.resend{value: stack.payment}(
             stack.redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -1011,7 +1014,8 @@ contract TestCoreRelayer is Test {
         );
 
         redeliveryVmHash = relayerWormhole.parseVM(fakeVM).hash;
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
+        uint256 txValue = stack.payment + map[differentChainId].wormhole.messageFee();
+        vm.deal(setup.target.relayer, txValue);
 
         vm.expectEmit(true, true, true, true, address(map[differentChainId].coreRelayer));
         emit Delivery({
@@ -1022,23 +1026,19 @@ contract TestCoreRelayer is Test {
             status: DeliveryStatus.INVALID_REDELIVERY
         });
         vm.prank(setup.target.relayer);
-        map[differentChainId].coreRelayerFull.redeliverSingle{
-            value: stack.payment + map[differentChainId].wormhole.messageFee()
-        }(stack.package);
-
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
+        map[differentChainId].coreRelayerFull.redeliverSingle{value: txValue}(stack.package);
 
         stack.package = CoreRelayerStructs.TargetRedeliveryByTxHashParamsSingle({
             redeliveryVM: correctVM,
             sourceEncodedVMs: stack.originalDelivery.encodedVMs,
             relayerRefundAddress: payable(setup.target.relayer)
         });
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
+        vm.deal(setup.target.relayer, stack.budget - 1);
         vm.expectRevert(abi.encodeWithSignature("InsufficientRelayerFunds()"));
         vm.prank(setup.target.relayer);
         setup.target.coreRelayerFull.redeliverSingle{value: stack.budget - 1}(stack.package);
 
-        vm.deal(setup.target.relayer, type(uint256).max >> 2);
+        vm.deal(setup.target.relayer, stack.budget);
 
         assertTrue(
             (keccak256(setup.target.integration.getMessage()) != keccak256(message))
@@ -1124,7 +1124,7 @@ contract TestCoreRelayer is Test {
             stack.budget = stack.instruction.maximumRefundTarget + stack.instruction.receiverValueTarget
                 + setup.source.wormhole.messageFee();
 
-            vm.deal(setup.source.relayer, type(uint256).max >> 2);
+            vm.deal(setup.source.relayer, stack.budget);
             vm.prank(setup.source.relayer);
             vm.expectRevert(abi.encodeWithSignature("SendNotSufficientlyFunded()"));
             setup.source.coreRelayerFull.deliverSingle{value: stack.budget}(stack.package);

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -220,8 +220,8 @@ contract TestCoreRelayer is Test {
         CoreRelayer coreRelayerFull;
         MockRelayerIntegration integration;
         address relayer;
-        address rewardAddress;
-        address refundAddress;
+        address payable rewardAddress;
+        address payable refundAddress;
         uint16 chainId;
     }
 
@@ -236,8 +236,10 @@ contract TestCoreRelayer is Test {
             mapEntry.coreRelayerFull = CoreRelayer(address(mapEntry.coreRelayer));
             mapEntry.integration = new MockRelayerIntegration(address(mapEntry.wormhole), address(mapEntry.coreRelayer));
             mapEntry.relayer = address(uint160(uint256(keccak256(abi.encodePacked(bytes("relayer"), i)))));
-            mapEntry.refundAddress = address(uint160(uint256(keccak256(abi.encodePacked(bytes("refundAddress"), i)))));
-            mapEntry.rewardAddress = address(uint160(uint256(keccak256(abi.encodePacked(bytes("rewardAddress"), i)))));
+            mapEntry.refundAddress =
+                payable(address(uint160(uint256(keccak256(abi.encodePacked(bytes("refundAddress"), i))))));
+            mapEntry.rewardAddress =
+                payable(address(uint160(uint256(keccak256(abi.encodePacked(bytes("rewardAddress"), i))))));
             mapEntry.chainId = i;
             map[i] = mapEntry;
         }

--- a/ethereum/forge-test/CoreRelayer.t.sol
+++ b/ethereum/forge-test/CoreRelayer.t.sol
@@ -596,7 +596,7 @@ contract TestCoreRelayer is Test {
             newRelayParameters: setup.source.coreRelayer.getDefaultRelayParams()
         });
 
-        vm.deal(address(this), type(uint256).max);
+        vm.deal(address(this), type(uint256).max >> 2);
 
         setup.source.coreRelayer.resend{value: payment + newMaxTransactionFeeFee}(
             redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -655,7 +655,7 @@ contract TestCoreRelayer is Test {
             newRelayParameters: setup.source.coreRelayer.getDefaultRelayParams()
         });
 
-        vm.deal(address(this), type(uint256).max);
+        vm.deal(address(this), type(uint256).max >> 2);
 
         setup.source.coreRelayer.resend{value: payment + newMaxTransactionFeeFee}(
             redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -720,7 +720,7 @@ contract TestCoreRelayer is Test {
 
         vm.getRecordedLogs();
 
-        vm.deal(address(this), type(uint256).max);
+        vm.deal(address(this), type(uint256).max >> 2);
 
         setup.source.integration.sendMessageWithRefundAddress{value: payment}(
             secondMessage, setup.targetChainId, address(setup.target.integration), address(setup.target.refundAddress)
@@ -844,7 +844,7 @@ contract TestCoreRelayer is Test {
             newReceiverValue: 0,
             newRelayParameters: setup.source.coreRelayer.getDefaultRelayParams()
         });
-        vm.deal(address(this), type(uint256).max);
+        vm.deal(address(this), type(uint256).max >> 2);
         vm.expectRevert(abi.encodeWithSignature("MsgValueTooLow()"));
         setup.source.coreRelayer.resend{value: stack.payment - 1}(
             stack.redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -877,7 +877,7 @@ contract TestCoreRelayer is Test {
         stack.budget = stack.instruction.newMaximumRefundTarget + stack.instruction.newReceiverValueTarget
             + setup.target.wormhole.messageFee();
 
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
 
         vm.prank(setup.target.relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidVaa(uint8)", 2));
@@ -923,7 +923,7 @@ contract TestCoreRelayer is Test {
         setup.target.coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
 
         setup.source.relayProvider.updateDeliveryAddress(setup.targetChainId, bytes32(uint256(uint160(address(this)))));
-        vm.deal(address(this), type(uint256).max);
+        vm.deal(address(this), type(uint256).max >> 2);
         vm.getRecordedLogs();
         setup.source.coreRelayer.resend{value: stack.payment}(
             stack.redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -963,7 +963,7 @@ contract TestCoreRelayer is Test {
         if (setup.targetChainId == 2) {
             differentChainId = 3;
         }
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
         vm.expectEmit(true, true, true, true, address(map[differentChainId].coreRelayer));
         emit Delivery({
             recipientContract: address(setup.target.integration),
@@ -975,7 +975,7 @@ contract TestCoreRelayer is Test {
         vm.prank(setup.target.relayer);
         map[differentChainId].coreRelayerFull.redeliverSingle{value: stack.budget}(stack.package);
 
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
 
         stack.redeliveryRequest = IWormholeRelayer.ResendByTx({
             sourceChain: setup.sourceChainId,
@@ -993,7 +993,7 @@ contract TestCoreRelayer is Test {
         setup.source.relayProvider.updateDeliveryAddress(
             differentChainId, bytes32(uint256(uint160(address(setup.target.relayer))))
         );
-        vm.deal(address(this), type(uint256).max);
+        vm.deal(address(this), type(uint256).max >> 2);
         vm.getRecordedLogs();
         setup.source.coreRelayer.resend{value: stack.payment}(
             stack.redeliveryRequest, 1, address(setup.source.relayProvider)
@@ -1011,7 +1011,7 @@ contract TestCoreRelayer is Test {
         );
 
         redeliveryVmHash = relayerWormhole.parseVM(fakeVM).hash;
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
 
         vm.expectEmit(true, true, true, true, address(map[differentChainId].coreRelayer));
         emit Delivery({
@@ -1026,19 +1026,19 @@ contract TestCoreRelayer is Test {
             value: stack.payment + map[differentChainId].wormhole.messageFee()
         }(stack.package);
 
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
 
         stack.package = CoreRelayerStructs.TargetRedeliveryByTxHashParamsSingle({
             redeliveryVM: correctVM,
             sourceEncodedVMs: stack.originalDelivery.encodedVMs,
             relayerRefundAddress: payable(setup.target.relayer)
         });
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
         vm.expectRevert(abi.encodeWithSignature("InsufficientRelayerFunds()"));
         vm.prank(setup.target.relayer);
         setup.target.coreRelayerFull.redeliverSingle{value: stack.budget - 1}(stack.package);
 
-        vm.deal(setup.target.relayer, type(uint256).max);
+        vm.deal(setup.target.relayer, type(uint256).max >> 2);
 
         assertTrue(
             (keccak256(setup.target.integration.getMessage()) != keccak256(message))
@@ -1124,7 +1124,7 @@ contract TestCoreRelayer is Test {
             stack.budget = stack.instruction.maximumRefundTarget + stack.instruction.receiverValueTarget
                 + setup.source.wormhole.messageFee();
 
-            vm.deal(setup.source.relayer, type(uint256).max);
+            vm.deal(setup.source.relayer, type(uint256).max >> 2);
             vm.prank(setup.source.relayer);
             vm.expectRevert(abi.encodeWithSignature("SendNotSufficientlyFunded()"));
             setup.source.coreRelayerFull.deliverSingle{value: stack.budget}(stack.package);

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -2,6 +2,7 @@
 solc_version = "0.8.17"
 optimizer = true
 optimizer_runs = 200
+via_ir = true
 extra_output = ["metadata", "storageLayout", "evm.deployedBytecode.immutableReferences"]
 
 src = "contracts"

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -16,8 +16,8 @@
     "ts-node": "^10.9.1"
   },
   "scripts": {
-    "build": "forge build -o build --via-ir",
-    "unit-test": "forge test -vvvvv --via-ir",
+    "build": "forge build -o build",
+    "unit-test": "forge test -vvvvv",
     "integration-test": "bash shell-scripts/run_integration_tests.sh",
     "typechain": "bash ../sdk/scripts/make_ethers_types.sh",
     "flatten": "mkdir -p node_modules/@poanet/solidity-flattener/contracts && cp -r contracts/* node_modules/@poanet/solidity-flattener/contracts/ && poa-solidity-flattener",


### PR DESCRIPTION
These changes are simplifications, which let the compiler emit more gas efficient code, and some "caching", i.e. call an internal function like `wormhole()` only once.

I focused on the `CoreRelayer` contract for now.

I think there are further opportunities for optimization in the way that the `CoreRelayer` contract interacts with the `RelayProvider` and in some memory intensive operations like the encoding of VAAs when there are several in a container.

Additionally, the `viaIR` compiler flag is set in `foundry.toml` to avoid having to pass the option while invoking `forge` directly.

I measured gas usage with `forge snapshot`. First, I ran `forge snapshot --via-ir` in the current `main` branch (d335a35abd58d06f726d88fd967706cb02c67408) and then I ran the following:

```
$ forge snapshot --diff

[...]
Test result: ok. 6 passed; 0 failed; finished in 2.49s

[...]
Test result: ok. 12 passed; 0 failed; finished in 4.15s
testCanUpdatePriceOnlyAsOwner(address,uint16,uint128,uint128) (gas: 0 (0.000%)) 
testCannotUpdatePriceWithChainIdZero(uint128,uint128) (gas: 0 (0.000%)) 
testCannotUpdatePriceWithGasPriceZero(uint16,uint128) (gas: 0 (0.000%)) 
testCannotUpdatePriceWithNativeCurrencyPriceZero(uint16,uint128) (gas: 0 (0.000%)) 
testUpdatePrice(uint16,uint128,uint64,uint128,uint64,uint32,uint32,uint32) (gas: 0 (0.000%)) 
testUpdatePrices(uint16,uint128,uint64,uint128,uint64,uint32,uint32,uint32) (gas: 0 (0.000%)) 
testRevertNonceZero((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: 24 (0.004%)) 
testRevertsendErrors((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: 45 (0.007%)) 
testForward((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -2721 (-0.099%)) 
testFundsCorrect((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -1721 (-0.103%)) 
testFundsCorrectIfApplicationCallReverts((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -1685 (-0.106%)) 
testSend((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -1826 (-0.112%)) 
testAttackForwardRequestCache((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256)) (gas: -3627 (-0.125%)) 
testTwoSends((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes,bytes) (gas: -3893 (-0.153%)) 
testRevertDeliveryErrors((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -4779 (-0.190%)) 
testRedelivery((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -4620 (-0.244%)) 
testApplicationBudgetFeeWithRedelivery((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -7218 (-0.331%)) 
testRevertRedeliveryErrors((uint32,uint32,uint128,uint128),(uint128,uint128,uint128,uint128,uint256),bytes) (gas: -13533 (-0.479%)) 
Overall gas change: -45554 (-0.138%)
```

Note that some tests call the contracts with more than one operation over and over again so those tests are biased to show greater gas difference.
Aside from this, the contract size for the `CoreRelayerImplementation` was `22240` bytes and after these changes it now is `21849`. It's not much, but it helps.